### PR TITLE
Use namespace aliases everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Implements: `std::identity` proposed in [Standard Library Concepts (P0898R3)](ht
 ```cpp
 #include <beman/exemplar/identity.hpp> 
 
+namespace exe = beman::exemplar;
+
 // Class with a pair of values.
 struct Pair
 {
@@ -43,7 +45,7 @@ struct Pair
 // e.g., pairs with custom projection: {1:one, 2:two, 3:three}
 template <std::ranges::input_range R,
           typename Projection>
-void print(const std::string_view rem, R &&range, Projection projection = beman::exemplar::identity>)
+void print(const std::string_view rem, R &&range, Projection projection = exe::identity>)
 {
     std::cout << rem << '{';
     std::ranges::for_each(

--- a/examples/identity_as_default_projection.cpp
+++ b/examples/identity_as_default_projection.cpp
@@ -5,13 +5,15 @@
 // TODO Darius: Do we need to selectively compile this example?
 // Or should we assume that this project is compiled with C++20 support only?
 
-#include <beman/exemplar/identity.hpp> // beman::exemplar::identity
+#include <beman/exemplar/identity.hpp>
 
 #include <algorithm>
 #include <functional> // std::identity
 #include <iostream>
 #include <ranges>
 #include <string>
+
+namespace exe = beman::exemplar;
 
 // Class with a pair of values.
 struct Pair
@@ -44,9 +46,9 @@ void print_helper(const std::string_view rem, R &&range, Projection projection)
     std::cout << "}\n";
 };
 
-// Print wrapper with beman::exemplar::identity.
+// Print wrapper with exe::identity.
 template <std::ranges::input_range R,
-          typename Projection = beman::exemplar::identity> // <- Notice the default projection.
+          typename Projection = exe::identity> // <- Notice the default projection.
 void print_beman(const std::string_view rem, R &&range, Projection projection = {})
 {
     print_helper(rem, range, projection);

--- a/examples/identity_direct_usage.cpp
+++ b/examples/identity_direct_usage.cpp
@@ -4,7 +4,9 @@
 
 #include <iostream>
 
+namespace exe = beman::exemplar;
+
 int main() {
-    std::cout << beman::exemplar::identity()(2024) << '\n';
+    std::cout << exe::identity()(2024) << '\n';
     return 0;
 }

--- a/src/beman/exemplar/identity.t.cpp
+++ b/src/beman/exemplar/identity.t.cpp
@@ -7,11 +7,13 @@
 #include <algorithm>
 #include <functional>
 
+namespace exe = beman::exemplar;
+
 TEST(IdentityTest, call_identity_with_int)
 {
     for (int i = -100; i < 100; ++i)
     {
-        EXPECT_EQ(i, beman::exemplar::identity()(i));
+        EXPECT_EQ(i, exe::identity()(i));
     }
 }
 
@@ -25,7 +27,7 @@ TEST(IdentityTest, call_identity_with_custom_type)
     for (int i = -100; i < 100; ++i)
     {
         const S s{i};
-        const S s_id = beman::exemplar::identity()(s);
+        const S s_id = exe::identity()(s);
         EXPECT_EQ(s.i, s_id.i);
     }
 }
@@ -35,7 +37,7 @@ TEST(IdentityTest, compare_std_vs_beman)
 // Requires: std::identity support.
 #if defined(__cpp_lib_identity)
     std::identity std_id;
-    beman::exemplar::identity beman_id;
+    exe::identity beman_id;
     for (int i = -100; i < 100; ++i)
     {
         EXPECT_EQ(std_id(i), beman_id(i));
@@ -48,7 +50,7 @@ TEST(IdentityTest, check_is_transparent)
 // Requires: transparent operators support.
 #if defined(__cpp_lib_transparent_operators)
 
-    beman::exemplar::identity id;
+    exe::identity id;
 
     const auto container = {1, 2, 3, 4, 5};
     auto it = std::find(std::begin(container), std::end(container), 3);


### PR DESCRIPTION
This stylisticly is an improvement as the user code is more clear.
