### PR TITLE
Update CI dependency versions

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -44,7 +44,7 @@ jobs:
           - { id: ubuntu-clang-static-cxx26, platform: ubuntu, cc: clang, cpp: clang++, cmake_args: "-DCMAKE_CXX_STANDARD=26 -DCMAKE_CXX_STANDARD_REQUIRED=on"}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # GitHub runners have updated the Ubuntu Linux Kernel to use strong ASLR,
       # but LLVM is not configured for this change, and thus the address
       # sanitizer breaks.
@@ -65,7 +65,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: false

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -6,12 +6,16 @@ on:
   push:
     branches: [ main ]
     paths:
+      - ".ci/**"
+      - ".github/workflow/**"
       - "src/**"
       - "test/**"
       - "CMakeLists.txt"
   pull_request:
     branches: [ main ]
     paths:
+      - ".ci/**"
+      - ".github/workflow/**"
       - "src/**"
       - "test/**"
       - "CMakeLists.txt"


### PR DESCRIPTION
This pr updates the continuous integration tools' version.
This fixes the warning "The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/" on the actions panel.
This pr also updates the continuous integration file so that it triggers when an update to its config is applied.