### PR TITLE
Update CI triggers

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -4,22 +4,7 @@ name: Continuous Integration Tests
 
 on:
   push:
-    branches: [ main ]
-    paths:
-      - ".ci/**"
-      - ".github/workflow/**"
-      - "src/**"
-      - "test/**"
-      - "CMakeLists.txt"
   pull_request:
-    branches: [ main ]
-    paths:
-      - ".ci/**"
-      - ".github/workflow/**"
-      - "src/**"
-      - "test/**"
-      - "CMakeLists.txt"
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  schedule:
+    - cron: '30 15 * * *'
 
 jobs:
   test:


### PR DESCRIPTION
This PR removes two requirements for the CI to trigger:
- Changes made so any branches can trigger the CI. See: https://github.com/beman-project/exemplar/issues/27#issuecomment-2370124356
- Changes made so any files can trigger the CI. As currently the only folder excluded from the white-list is the `/example` folder, which doesn't really make sense? We could miss build config update if we need to introduce more configuration files.

This PR also introduces nightly build-test (mentioned: https://github.com/beman-project/exemplar/issues/27#issuecomment-2370124356 ), the frequency of the periodic update is currently set at daily at 3:30 PM UTC (11:30 ET).
This timestamp and frequency is fairly arbitrary, meant to trigger 30 minutes before the weekly sync call.
The daily build maybe too frequent, this is all open to discussion. 