### PR TITLE
Disable installing gtest when `cmake --install`

### DIFF
--- a/.ci/docker/ubuntu.Dockerfile
+++ b/.ci/docker/ubuntu.Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Using a non-LTS Ubuntu, just until CMake 3.23 is available on Ubuntu 24.04.
+# Using a non-LTS Ubuntu, just until CMake 3.25 is available on Ubuntu 24.04.
 FROM ubuntu:23.10
 
 # Install dependencies,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # TODO Darius: Find CMake minimum required version.
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.25)
 
 project(
   beman.exemplar # CMake Project Name, which is also the name of the top-level
@@ -15,13 +15,16 @@ include(FetchContent)
 if(BUILD_TESTING)
   enable_testing()
 
-  # Fetch GoogleTest
-  FetchContent_Declare(
-    googletest
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG f8d7d77c06936315286eb55f8de22cd23c188571 # release-1.14.0
-    EXCLUDE_FROM_ALL CMAKE_ARGS -DBUILD_TESTING=OFF)
-  FetchContent_MakeAvailable(googletest)
+  block()
+    set(INSTALL_GTEST OFF)
+    # Fetch GoogleTest
+    FetchContent_Declare(
+      googletest
+      GIT_REPOSITORY https://github.com/google/googletest.git
+      GIT_TAG f8d7d77c06936315286eb55f8de22cd23c188571 # release-1.14.0
+      EXCLUDE_FROM_ALL CMAKE_ARGS -DBUILD_TESTING=OFF)
+    FetchContent_MakeAvailable(googletest)
+  endblock()
 endif()
 
 add_subdirectory(src/beman/exemplar)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# TODO Darius: Find CMake minimum required version.
 cmake_minimum_required(VERSION 3.25)
 
 project(
@@ -16,7 +15,9 @@ if(BUILD_TESTING)
   enable_testing()
 
   block()
+    # Disable installing google test dependency on cmake --install
     set(INSTALL_GTEST OFF)
+
     # Fetch GoogleTest
     FetchContent_Declare(
       googletest


### PR DESCRIPTION
closes #32 .

This pr updates the CMake file, and disables installing `gtest` headers when running `cmake --install`.

Note that this will require cmake 3.25 due to use of [`block`](https://cmake.org/cmake/help/latest/command/block.html).

See: https://github.com/beman-project/exemplar/pull/37/checks#step:6:320 for effect of this pr.