### PR TITLE
Set minimum required C++ version to C++17

### DIFF
--- a/src/beman/exemplar/CMakeLists.txt
+++ b/src/beman/exemplar/CMakeLists.txt
@@ -13,6 +13,8 @@ target_sources(
   BASE_DIRS ${INCLUDE_DIR}
   FILES ${INCLUDE_DIR}/beman/exemplar/identity.hpp)
 
+target_compile_features(beman.exemplar PUBLIC cxx_std_17)
+
 set_target_properties(beman.exemplar PROPERTIES VERIFY_INTERFACE_HEADER_SETS ON)
 
 install(


### PR DESCRIPTION
This is required for the nested namespace specifiers [in identity.hpp](https://github.com/beman-project/exemplar/blob/b8d4b0693cc1bd1881a74c42dd19cc6d49e27307/include/beman/exemplar/identity.hpp#L25).

Without this change, the example will fail to compile on MSVC.
If it is not desirable to have a C++17 as the minimum version, the example code should be changed to not rely on any C++17 features instead.