### PR TITLE
Simplify CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,18 +14,17 @@ include(FetchContent)
 if(BUILD_TESTING)
   enable_testing()
 
-  block()
-    # Disable installing google test dependency on cmake --install
-    set(INSTALL_GTEST OFF)
-
-    # Fetch GoogleTest
-    FetchContent_Declare(
-      googletest
-      GIT_REPOSITORY https://github.com/google/googletest.git
-      GIT_TAG f8d7d77c06936315286eb55f8de22cd23c188571 # release-1.14.0
-      EXCLUDE_FROM_ALL CMAKE_ARGS -DBUILD_TESTING=OFF)
-    FetchContent_MakeAvailable(googletest)
-  endblock()
+  # Fetch GoogleTest
+  FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG f8d7d77c06936315286eb55f8de22cd23c188571 # release-1.14.0
+    EXCLUDE_FROM_ALL
+    CMAKE_ARGS
+      -DBUILD_TESTING=OFF
+      -DINSTALL_GTEST=OFF
+    )
+  FetchContent_MakeAvailable(googletest)
 endif()
 
 add_subdirectory(src/beman/exemplar)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,11 +20,12 @@ if(BUILD_TESTING)
     GIT_REPOSITORY https://github.com/google/googletest.git
     GIT_TAG f8d7d77c06936315286eb55f8de22cd23c188571 # release-1.14.0
     EXCLUDE_FROM_ALL
-    CMAKE_ARGS
-      -DBUILD_TESTING=OFF
-      -DINSTALL_GTEST=OFF
-    )
-  FetchContent_MakeAvailable(googletest)
+  )
+  block()
+    set(INSTALL_GTEST OFF) # Disable GoogleTest installation
+    set(BUILD_TESTING OFF) # Disable GoogleTest tests
+    FetchContent_MakeAvailable(googletest)
+  endblock()
 endif()
 
 add_subdirectory(src/beman/exemplar)


### PR DESCRIPTION
The `block()` isn't needed since we can set CMake options
via. CMAKE_ARGS.
