### PR TITLE
Implement schedule fault notification

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -69,3 +69,32 @@ jobs:
         run: |
           docker run ${{ matrix.cfg.id }} ctest --test-dir build -C Release
           docker run ${{ matrix.cfg.id }} ctest --test-dir build -C Debug
+
+  create-issue-when-fault:
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: failure() && github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+      # See https://github.com/cli/cli/issues/5075 
+      - name: Create issue
+        run: |
+          issue_num=$(gh issue list -s open -S "[SCHEDULED-BUILD] Build & Test failure" -L 1 --json number | jq 'if length == 0 then -1 else .[0].number end')
+          
+          body="**Build-and-Test Failure Report**
+          - **Time of Failure**: $(date -u '+%B %d, %Y, %H:%M %Z')
+          - **Commit**: [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
+          - **Action Run**: [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          
+          The scheduled build-and-test triggered by cron has failed.
+          Please investigate the logs and recent changes associated with this commit."
+          
+          echo $body
+          
+          if [[ $issue_num -eq -1 ]]; then
+            gh issue create --repo ${{ github.repository }} --title "[SCHEDULED-BUILD] Build & Test failure" --body "$body"
+          else
+            gh issue comment --repo ${{ github.repository }} $issue_num --body "$body"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -75,8 +75,8 @@ jobs:
     needs: [test]
     if: failure() && github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@v4
       # See https://github.com/cli/cli/issues/5075 
+      - uses: actions/checkout@v4
       - name: Create issue
         run: |
           issue_num=$(gh issue list -s open -S "[SCHEDULED-BUILD] Build & Test failure" -L 1 --json number | jq 'if length == 0 then -1 else .[0].number end')
@@ -87,9 +87,7 @@ jobs:
           - **Action Run**: [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
           
           The scheduled build-and-test triggered by cron has failed.
-          Please investigate the logs and recent changes associated with this commit."
-          
-          echo $body
+          Please investigate the logs and recent changes associated with this commit or rerun the workflow if you believe this is an error."
           
           if [[ $issue_num -eq -1 ]]; then
             gh issue create --repo ${{ github.repository }} --title "[SCHEDULED-BUILD] Build & Test failure" --body "$body"


### PR DESCRIPTION
closes #36 . 

Scheduled build-and-test introduced in #28 is triggering correctly.
But failure at routine build-and-test can be silent, e. g. https://github.com/beman-project/exemplar/actions/runs/11109516669 .

This pr creates a new issue when scheduled build-and-test fails.
To avoid spamming the issue tracker, it will append to an existing open issue with a comment if an previously opened issue exist and is active.

Tested on my own fork, see: https://github.com/wusatosi/exemplar/issues/6