### PR TITLE
Create CMake preset

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -11,6 +11,21 @@ on:
     - cron: '30 15 * * *'
 
 jobs:
+  preset-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        preset: ["gcc-debug", "gcc-release"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.25.x'
+      - uses: seanmiddleditch/gha-setup-ninja@v5
+      - name: Run preset
+        run: cmake --workflow --preset ${{ matrix.preset }}
+      
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -72,7 +87,7 @@ jobs:
 
   create-issue-when-fault:
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [test, preset-test]
     if: failure() && github.event_name == 'schedule'
     steps:
       # See https://github.com/cli/cli/issues/5075 

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -87,7 +87,7 @@ jobs:
 
   create-issue-when-fault:
     runs-on: ubuntu-latest
-    needs: [test, preset-test]
+    needs: [preset-test, test]
     if: failure() && github.event_name == 'schedule'
     steps:
       # See https://github.com/cli/cli/issues/5075 

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: seanmiddleditch/gha-setup-ninja@v5
       - name: Run preset
         run: cmake --workflow --preset ${{ matrix.preset }}
-      
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,121 @@
+{
+  "version": 6,
+  "configurePresets": [
+    {
+      "name": "_root-config",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_CXX_STANDARD": "20"
+      }
+    },
+    {
+      "name": "_debug-base",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_CXX_FLAGS": "-g -fsanitize=address -fsanitize=pointer-compare -fsanitize=pointer-subtract -fsanitize=leak -fsanitize=undefined"
+      }
+    },
+    {
+      "name": "_release-base",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_CXX_FLAGS": "-g -O3"
+      }
+    },
+    {
+      "name": "gcc-debug",
+      "displayName": "GCC Debug Build",
+      "inherits": [
+        "_root-config",
+        "_debug-base"
+      ],
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "g++"
+      }
+    },
+    {
+      "name": "gcc-release",
+      "displayName": "GCC Release Build",
+      "inherits": [
+        "_root-config",
+        "_release-base"
+      ],
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "g++"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "gcc-debug",
+      "configurePreset": "gcc-debug"
+    },
+    {
+      "name": "gcc-release",
+      "configurePreset": "gcc-release"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "_test_base",
+      "hidden": true,
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "noTestsAction": "error",
+        "stopOnFailure": true
+      }
+    },
+    {
+      "name": "gcc-debug",
+      "inherits": "_test_base",
+      "configurePreset": "gcc-debug"
+    },
+    {
+      "name": "gcc-release",
+      "inherits": "_test_base",
+      "configurePreset": "gcc-release"
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "gcc-debug",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "gcc-debug"
+        },
+        {
+          "type": "build",
+          "name": "gcc-debug"
+        },
+        {
+          "type": "test",
+          "name": "gcc-debug"
+        }
+      ]
+    },
+    {
+      "name": "gcc-release",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "gcc-release"
+        },
+        {
+          "type": "build",
+          "name": "gcc-release"
+        },
+        {
+          "type": "test",
+          "name": "gcc-release"
+        }
+      ]
+    }
+  ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,7 +15,7 @@
       "hidden": true,
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_CXX_FLAGS": "-g -fsanitize=address -fsanitize=pointer-compare -fsanitize=pointer-subtract -fsanitize=leak -fsanitize=undefined"
+        "CMAKE_CXX_FLAGS": "-fsanitize=address -fsanitize=pointer-compare -fsanitize=pointer-subtract -fsanitize=leak -fsanitize=undefined"
       }
     },
     {
@@ -23,7 +23,7 @@
       "hidden": true,
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-        "CMAKE_CXX_FLAGS": "-g -O3"
+        "CMAKE_CXX_FLAGS": "-O3"
       }
     },
     {

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ This project strives to be as normal and simple a CMake project as possible. Thi
 
 ```shell
 cmake --workflow --preset gcc-debug
-cmake --install build --prefix /opt/beman.exemplar
+cmake --workflow --preset gcc-release
+cmake --install build/gcc-release --prefix /opt/beman.exemplar
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -170,10 +170,10 @@ Preset CMake variables:
 -- Check for working C compiler: /usr/bin/cc - skipped
 -- Detecting C compile features
 -- Detecting C compile features - done
--- Found Python3: /usr/bin/python3.10 (found version "3.10.12") found components: Interpreter 
+-- Found Python3: /usr/bin/python3.10 (found version "3.10.12") found components: Interpreter
 -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
 -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
--- Found Threads: TRUE  
+-- Found Threads: TRUE
 -- Configuring done
 -- Generating done
 -- Build files have been written to: /home/runner/work/exemplar/exemplar/build/gcc-debug
@@ -234,10 +234,10 @@ Preset CMake variables:
 -- Check for working C compiler: /usr/bin/cc - skipped
 -- Detecting C compile features
 -- Detecting C compile features - done
--- Found Python3: /usr/bin/python3.10 (found version "3.10.12") found components: Interpreter 
+-- Found Python3: /usr/bin/python3.10 (found version "3.10.12") found components: Interpreter
 -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
 -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
--- Found Threads: TRUE  
+-- Found Threads: TRUE
 -- Configuring done
 -- Generating done
 -- Build files have been written to: /home/runner/work/exemplar/exemplar/build/gcc-release
@@ -276,7 +276,7 @@ Test project /home/runner/work/exemplar/exemplar/build/gcc-release
 Total Test time (real) =   0.01 sec
 
 # Run examples.
-$ build/gcc-release/examples/beman.exemplar.examples.identity_direct_usage 
+$ build/gcc-release/examples/beman.exemplar.examples.identity_direct_usage
 2024
 
 ```

--- a/README.md
+++ b/README.md
@@ -143,40 +143,121 @@ cmake --install build/gcc-release --prefix /opt/beman.exemplar
 <summary> Build beman.exemplar (verbose logs) </summary>
 
 ```shell
-# Configure beman.exemplar.
-$ cmake -B build -S . -DCMAKE_CXX_STANDARD=20
--- The CXX compiler identification is GNU 13.2.0
+# Configure beman.exemplar via gcc-debug workflow for development.
+$ cmake --workflow --preset gcc-debug
+Executing workflow step 1 of 3: configure preset "gcc-debug"
+
+Preset CMake variables:
+
+  CMAKE_BUILD_TYPE="Debug"
+  CMAKE_CXX_COMPILER="g++"
+  CMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=pointer-compare -fsanitize=pointer-subtract -fsanitize=leak -fsanitize=undefined"
+  CMAKE_CXX_STANDARD="20"
+
+-- The CXX compiler identification is GNU 11.4.0
 -- Detecting CXX compiler ABI info
 -- Detecting CXX compiler ABI info - done
--- Check for working CXX compiler: /usr/bin/c++ - skipped
+-- Check for working CXX compiler: /usr/bin/g++ - skipped
 -- Detecting CXX compile features
 -- Detecting CXX compile features - done
--- Configuring done (0.1s)
--- Generating done (0.0s)
--- Build files have been written to: /path/to/repo/build
+-- The C compiler identification is GNU 11.4.0
+-- Detecting C compiler ABI info
+-- Detecting C compiler ABI info - done
+-- Check for working C compiler: /usr/bin/cc - skipped
+-- Detecting C compile features
+-- Detecting C compile features - done
+-- Found Python3: /usr/bin/python3.10 (found version "3.10.12") found components: Interpreter 
+-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
+-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
+-- Found Threads: TRUE  
+-- Configuring done
+-- Generating done
+-- Build files have been written to: /home/runner/work/exemplar/exemplar/build/gcc-debug
 
-# Build beman.exemplar.
-$ cmake --build build
-[ 10%] Building CXX object src/beman/exemplar/CMakeFiles/beman.exemplar.dir/identity.cpp.o
-[ 20%] Linking CXX static library libbeman.exemplar.a
-[ 20%] Built target beman.exemplar
-[ 30%] Building CXX object _deps/googletest-build/googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o
-[ 40%] Linking CXX static library ../../../lib/libgtest.a
-[ 40%] Built target gtest
-[ 50%] Building CXX object _deps/googletest-build/googletest/CMakeFiles/gtest_main.dir/src/gtest_main.cc.o
-[ 60%] Linking CXX static library ../../../lib/libgtest_main.a
-[ 60%] Built target gtest_main
-[ 70%] Building CXX object src/beman/exemplar/tests/CMakeFiles/beman.exemplar.Test.dir/identity.t.cpp.o
-[ 80%] Linking CXX executable beman.exemplar.Test
-[ 80%] Built target beman.exemplar.Test
-[ 90%] Building CXX object examples/CMakeFiles/identity_usage.dir/identity_usage.cpp.o
-[100%] Linking CXX executable identity_usage
-[100%] Built target identity_usage
+Executing workflow step 2 of 3: build preset "gcc-debug"
 
-# Run beman.exemplar tests.
-$ ctest --test-dir build
-Internal ctest changing into directory: /path/to/your/repo/build
-Test project /path/to/your/repo/build
+[1/14] Building CXX object src/beman/exemplar/CMakeFiles/beman.exemplar.dir/identity.cpp.o
+[2/14] Linking CXX static library src/beman/exemplar/libbeman.exemplar.a
+[3/14] Building CXX object examples/CMakeFiles/beman.exemplar.examples.identity_direct_usage.dir/identity_direct_usage.cpp.o
+[4/14] Linking CXX executable examples/beman.exemplar.examples.identity_direct_usage
+[5/14] Building CXX object _deps/googletest-build/googletest/CMakeFiles/gtest_main.dir/src/gtest_main.cc.o
+[6/14] Building CXX object src/beman/exemplar/CMakeFiles/beman.exemplar.tests.dir/identity.t.cpp.o
+[7/14] Building CXX object _deps/googletest-build/googlemock/CMakeFiles/gmock_main.dir/src/gmock_main.cc.o
+[8/14] Building CXX object _deps/googletest-build/googlemock/CMakeFiles/gmock.dir/src/gmock-all.cc.o
+[9/14] Building CXX object _deps/googletest-build/googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o
+[10/14] Linking CXX static library lib/libgtest.a
+[11/14] Linking CXX static library lib/libgtest_main.a
+[12/14] Linking CXX static library lib/libgmock.a
+[13/14] Linking CXX static library lib/libgmock_main.a
+[14/14] Linking CXX executable src/beman/exemplar/beman.exemplar.tests
+
+Executing workflow step 3 of 3: test preset "gcc-debug"
+
+Test project /home/runner/work/exemplar/exemplar/build/gcc-debug
+    Start 1: IdentityTest.call_identity_with_int
+1/4 Test #1: IdentityTest.call_identity_with_int ...........   Passed    0.13 sec
+    Start 2: IdentityTest.call_identity_with_custom_type
+2/4 Test #2: IdentityTest.call_identity_with_custom_type ...   Passed    0.01 sec
+    Start 3: IdentityTest.compare_std_vs_beman
+3/4 Test #3: IdentityTest.compare_std_vs_beman .............   Passed    0.01 sec
+    Start 4: IdentityTest.check_is_transparent
+4/4 Test #4: IdentityTest.check_is_transparent .............   Passed    0.01 sec
+
+100% tests passed, 0 tests failed out of 4
+
+Total Test time (real) =   0.18 sec
+
+# Configure beman.exemplar via gcc-release workflow for direct usage.
+$ cmake --workflow --preset gcc-release
+Executing workflow step 1 of 3: configure preset "gcc-release"
+
+Preset CMake variables:
+
+  CMAKE_BUILD_TYPE="RelWithDebInfo"
+  CMAKE_CXX_COMPILER="g++"
+  CMAKE_CXX_FLAGS="-O3"
+  CMAKE_CXX_STANDARD="20"
+
+-- The CXX compiler identification is GNU 11.4.0
+-- Detecting CXX compiler ABI info
+-- Detecting CXX compiler ABI info - done
+-- Check for working CXX compiler: /usr/bin/g++ - skipped
+-- Detecting CXX compile features
+-- Detecting CXX compile features - done
+-- The C compiler identification is GNU 11.4.0
+-- Detecting C compiler ABI info
+-- Detecting C compiler ABI info - done
+-- Check for working C compiler: /usr/bin/cc - skipped
+-- Detecting C compile features
+-- Detecting C compile features - done
+-- Found Python3: /usr/bin/python3.10 (found version "3.10.12") found components: Interpreter 
+-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
+-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
+-- Found Threads: TRUE  
+-- Configuring done
+-- Generating done
+-- Build files have been written to: /home/runner/work/exemplar/exemplar/build/gcc-release
+
+Executing workflow step 2 of 3: build preset "gcc-release"
+
+[1/14] Building CXX object src/beman/exemplar/CMakeFiles/beman.exemplar.dir/identity.cpp.o
+[2/14] Linking CXX static library src/beman/exemplar/libbeman.exemplar.a
+[3/14] Building CXX object examples/CMakeFiles/beman.exemplar.examples.identity_direct_usage.dir/identity_direct_usage.cpp.o
+[4/14] Linking CXX executable examples/beman.exemplar.examples.identity_direct_usage
+[5/14] Building CXX object _deps/googletest-build/googletest/CMakeFiles/gtest_main.dir/src/gtest_main.cc.o
+[6/14] Building CXX object src/beman/exemplar/CMakeFiles/beman.exemplar.tests.dir/identity.t.cpp.o
+[7/14] Building CXX object _deps/googletest-build/googlemock/CMakeFiles/gmock_main.dir/src/gmock_main.cc.o
+[8/14] Building CXX object _deps/googletest-build/googlemock/CMakeFiles/gmock.dir/src/gmock-all.cc.o
+[9/14] Building CXX object _deps/googletest-build/googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o
+[10/14] Linking CXX static library lib/libgtest.a
+[11/14] Linking CXX static library lib/libgtest_main.a
+[12/14] Linking CXX static library lib/libgmock.a
+[13/14] Linking CXX executable src/beman/exemplar/beman.exemplar.tests
+[14/14] Linking CXX static library lib/libgmock_main.a
+
+Executing workflow step 3 of 3: test preset "gcc-release"
+
+Test project /home/runner/work/exemplar/exemplar/build/gcc-release
     Start 1: IdentityTest.call_identity_with_int
 1/4 Test #1: IdentityTest.call_identity_with_int ...........   Passed    0.00 sec
     Start 2: IdentityTest.call_identity_with_custom_type
@@ -190,9 +271,8 @@ Test project /path/to/your/repo/build
 
 Total Test time (real) =   0.01 sec
 
-
 # Run examples.
-$ build/exemplar/beman.exemplar.examples.identity_direct_usage
+$ build/gcc-release/examples/beman.exemplar.examples.identity_direct_usage 
 2024
 
 ```
@@ -204,13 +284,11 @@ $ build/exemplar/beman.exemplar.examples.identity_direct_usage
 
 ```shell
 # Install build artifacts from `build` directory into `opt/beman.exemplar` path.
-$ cmake --install build --prefix /opt/beman.exemplar
--- Install configuration: ""
+$ cmake --install build/gcc-release --prefix /opt/beman.exemplar
+-- Install configuration: "RelWithDebInfo"
 -- Up-to-date: /opt/beman.exemplar/lib/libbeman.exemplar.a
--- Up-to-date: /opt/beman.exemplar/include
--- Up-to-date: /opt/beman.exemplar/include/beman
--- Up-to-date: /opt/beman.exemplar/include/beman/exemplar
 -- Up-to-date: /opt/beman.exemplar/include/beman/exemplar/identity.hpp
+
 
 # Check tree.
 $ tree /opt/beman.exemplar
@@ -222,7 +300,7 @@ $ tree /opt/beman.exemplar
 └── lib
     └── libbeman.exemplar.a
 
-5 directories, 2 files
+4 directories, 2 files
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -134,9 +134,7 @@ apt-get install                           \
 This project strives to be as normal and simple a CMake project as possible. This build workflow in particular will work, producing a static `libbeman.exemplar.a` library, ready to package with its headers:
 
 ```shell
-cmake -B build -S . -DCMAKE_CXX_STANDARD=20
-cmake --build build
-ctest --test-dir build
+cmake --workflow --preset gcc-debug
 cmake --install build --prefix /opt/beman.exemplar
 ```
 


### PR DESCRIPTION
closes #17 .

This is a work in process seeking feedback, currently only included gcc related workflows.
Needs feedback on which compiler and what flags I should include/ exclude.
Let's keep the list of presets short (https://github.com/beman-project/exemplar/issues/17#issuecomment-2362899915) so we don't strain the CI system too much.

I omitted `-Werror` in #5 as this flag isn't indicated elsewhere (e.g. README).

There's two workflow presets:
- `gcc-debug`, (`-g` with all non-conflicting sanitizer included, see: https://github.com/beman-project/exemplar/issues/17#issuecomment-2377042239)
- `gcc-release`, (`-g` with `-O3`)

Assumes C++ 20 per: https://github.com/beman-project/exemplar/pull/38#issuecomment-2391421004 , but will monitor the progress happening at #38 . Please forward minimum version discussion to that thread unless it should be specific to a workflow.

CI test is only meant to test if the workflow config is functional, main testing should be done in the main build & test matrix, thus there's no cross-platform test. We could merge the two but that will need future discussion.

This is also a good peak into docker-less build & test for CI.

Please test this locally, I have experienced the test process hanging, possibly due to the excessive amount of sanitizer enabled. We may need to include a warning in the README to advise turning off/ splitting specific performance-impacting sanitizer on bigger projects.

Related pr: #7 