### PR TITLE
Fix review dog

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -44,5 +44,5 @@ jobs:
         uses: reviewdog/action-suggester@v1
         with:
           tool_name: pre-commit
-          fail_on_error: true
           level: warning
+          reviewdog_flags: "-fail-level=error"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,8 @@ jobs:
     name: pre-commit
     permissions:
       contents: read
+      checks: write
+      issues: write
       pull-requests: write
 
     steps:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -23,12 +23,6 @@ jobs:
         with:
           python-version: 3.13
 
-      - name: Cache pre-commit hooks
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
-
       - name: Get Changed Files
         id: changed-files
         uses: tj-actions/changed-files@v45

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -35,6 +35,7 @@ jobs:
         continue-on-error: true
 
       - name: suggester / pre-commit
+        if: ${{ github.event_name == 'pull_request' }}
         uses: reviewdog/action-suggester@v1
         with:
           tool_name: pre-commit


### PR DESCRIPTION
closes #49 

Reviewdog introduced in #46 is lacking permission to create annotations, see #49 for error logs on #48, commit: 6ec3d4f2aba30d8ff18cda32cec8ea3538b02c60 .

Also 
1. fixed use of deprecated `fail-on-error`, causing warning at: https://github.com/beman-project/exemplar/actions/runs/11411671176/job/31756356511?pr=48#step:7:234
2. Removed unnecessary caching behavior, see: https://github.com/beman-project/exemplar/pull/46#pullrequestreview-2375594753
3. Only trigger review dog on pull request (currently commits will also trigger review dog). 

See example at: https://github.com/wusatosi/exemplar/pull/11

CC: @linusboehm 