### PR TITLE
Proper permission fix for reviewdog

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,21 +1,19 @@
 name: Lint Check (pre-commit)
 
 on:
-  pull_request:
+  # We have to use pull_request_target here as pull_request does not grant
+  # enough permission for reviewdog
+  pull_request_target:
   push:
 
 jobs:
-  pre-commit:
+  pre-commit-push:
+    name: Pre-Commit check on Push
     runs-on: ubuntu-latest
-    name: pre-commit
-    permissions:
-      contents: read
-      checks: write
-      issues: write
-      pull-requests: write
+    if: ${{ github.event_name == 'push' }}
 
     steps:
-      - name: Checkout code
+      - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Set up Python
@@ -23,6 +21,40 @@ jobs:
         with:
           python-version: 3.13
 
+        # We wish to run pre-commit on all files instead of the changes
+        # only made in the push commit.
+        #
+        # So linting error persists when there's formatting problem.
+      - uses: pre-commit/action@v3.0.1
+
+  pre-commit-pr:
+    name: Pre-Commit check on PR
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request_target' }}
+
+    permissions:
+      contents: read
+      checks: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+        # pull_request_target checkout the base of the repo
+        # We need to checkout the actual pr to lint the changes.
+      - name: Checkout pr
+        run: gh pr checkout ${{ github.event.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+
+        # we only lint on the changed file in PR.
       - name: Get Changed Files
         id: changed-files
         uses: tj-actions/changed-files@v45
@@ -30,13 +62,14 @@ jobs:
         # See:
         # https://github.com/tj-actions/changed-files?tab=readme-ov-file#using-local-git-directory-
       - uses: pre-commit/action@v3.0.1
+        id: run-pre-commit
         with:
           extra_args: --files ${{ steps.changed-files.outputs.all_changed_files }}
-        continue-on-error: true
 
+        # Review dog posts the suggested change from pre-commit to the pr.
       - name: suggester / pre-commit
-        if: ${{ github.event_name == 'pull_request' }}
         uses: reviewdog/action-suggester@v1
+        if: ${{ failure() && steps.run-pre-commit.conclusion == 'failure' }}
         with:
           tool_name: pre-commit
           level: warning


### PR DESCRIPTION
This pr fixes the permission issue pre-commit GitHub Action was experiencing.

Turns out GitHub issues conservative permission to pull requests coming from a private fork, see: [link](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token).

To get write permission, we need to use `pull_request_target` as event trigger instead. In `pull_request_target` GitHub Actions checks out the base branch instead of the pr, so we need to manually checkout the pull request via GitHub CLI.

See: https://github.com/bean-men/testing-exempler/pull/6 as an example of correct output. Note that the pr come from my private fork from `wusatosi/testing-exempler` to an org in `bean-man/testing-exempler`.

Due to the introduced complexity, this pr also splits the `pre-commit` check for push and pull-request into two different jobs.

Closes #49 . (again).