### PR TITLE
Support Conan dependencies

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,14 @@
+[layout]
+cmake_layout
+
+[requires]
+
+[tool_requires]
+cmake/3.25.0
+
+[test_requires]
+gtest/1.15.0
+
+[generators]
+CMakeDeps
+CMakeToolchain


### PR DESCRIPTION
* Add a `conanfile.txt` to list Conan dependencies

This will provide consistent, cross-platform development workflows when using Conan for managing dependencies (i.e., CMake and GoogleTest). This is an intermediate step towards #133, but this change does not fully package this project for Conan. That would require authoring a `conanfile.py` file, either in this repo or (my preference) in the upstream ConanCenter repo.

I'm going to leave this as a Draft until the following is true of this PR:

* [ ] Wire up the newly supported workflow to CI. CI should fail if `conanfile.txt` is missing, empty, or otherwise not meeting requirements. This could provide a consistent Conan-based CI on all supported OSs if that's attractive.

* [ ] Add documentation demonstrating the support for building against Conan dependencies.