### PR TITLE
Fix duplicative CI runs when updating a pull request

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -4,6 +4,8 @@ name: Continuous Integration Tests
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,6 +5,8 @@ on:
   # enough permission for reviewdog
   pull_request_target:
   push:
+    branches:
+      - main
 
 jobs:
   pre-commit-push:

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
@@ -5,6 +5,8 @@ name: Continuous Integration Tests
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
   schedule:

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit.yml
@@ -6,6 +6,8 @@ on:
   # enough permission for reviewdog
   pull_request_target:
   push:
+    branches:
+      - main
 
 jobs:
   pre-commit-push:


### PR DESCRIPTION
When updating the branch associated with a pull request, previously, CI would trigger twice: once for the update to the branch, and another time for the update to the pull request itself.

This commit addresses the issue by restricting CI runs for updates to branches to those that update the main branch itself.