### PR TITLE
Remove debug setting from check_cookiecutter.sh script

### DIFF
--- a/cookiecutter/check_cookiecutter.sh
+++ b/cookiecutter/check_cookiecutter.sh
@@ -2,8 +2,6 @@
 
 set -euo pipefail
 
-set -x
-
 declare script_dir=$(realpath $(dirname "$BASH_SOURCE"))
 
 function check_consistency() {


### PR DESCRIPTION
The set +x here was needed for debugging but checking it in was accidental. This commit removes it.
