### PR TITLE
Add .gitattributes to help GitHub Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 infra/** linguist-vendored
 cookiecutter/** linguist-vendored
+*.bib -linguist-detectable
+*.tex -linguist-detectable
+papers/* linguist-documentation

--- a/cookiecutter/{{cookiecutter.project_name}}/.gitattributes
+++ b/cookiecutter/{{cookiecutter.project_name}}/.gitattributes
@@ -1,2 +1,5 @@
 infra/** linguist-vendored
 cookiecutter/** linguist-vendored
+*.bib -linguist-detectable
+*.tex -linguist-detectable
+papers/* linguist-documentation


### PR DESCRIPTION
## Description

This PR addresses the issues described in #192.

I merged this to `main` on my fork and the results are as follows:
![image](https://github.com/user-attachments/assets/46058fc9-54fb-477b-b81b-1d15d223d111)

## Meta

I'm not so sure about whether this should be merged to exemplar, considering the fact that `cookiecutter/` is a bona fide part of this repo. But I think that this `.gitattributes` file should definitely be there in repos generated from the template, like `indices_view`, `copyable_function`, etc.

- [x] If all approvals are obtained and the PR is green, any Beman member can merge the PR.

<!-- make sure you run pre-commit before opening a PR -->
