### PR TITLE
Specify --output-on-failure when running ctest in CI

### DIFF
--- a/.github/workflows/reusable-beman-build-and-test.yml
+++ b/.github/workflows/reusable-beman-build-and-test.yml
@@ -105,6 +105,7 @@ jobs:
           echo "build_config=${test%%[.]*}" >> "$GITHUB_OUTPUT"
           test_type=${test##*[.]}
           case $test_type in
+            Default) ;;
             TSan)
               echo "cmake_extra_args=-DBEMAN_BUILDSYS_SANITIZER=TSan" >> "$GITHUB_OUTPUT" ;;
             MaxSan)
@@ -142,4 +143,4 @@ jobs:
           ls -R /opt/beman.package
       - name: Test
         shell: bash
-        run: ctest --test-dir build --build-config ${{ steps.vars.outputs.build_config }}
+        run: ctest --test-dir build --build-config ${{ steps.vars.outputs.build_config }} --output-on-failure

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/reusable-beman-build-and-test.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/reusable-beman-build-and-test.yml
@@ -106,6 +106,7 @@ jobs:
           echo "build_config=${test%%[.]*}" >> "$GITHUB_OUTPUT"
           test_type=${test##*[.]}
           case $test_type in
+            Default) ;;
             TSan)
               echo "cmake_extra_args=-DBEMAN_BUILDSYS_SANITIZER=TSan" >> "$GITHUB_OUTPUT" ;;
             MaxSan)
@@ -143,5 +144,5 @@ jobs:
           ls -R /opt/beman.package
       - name: Test
         shell: bash
-        run: ctest --test-dir build --build-config ${{ steps.vars.outputs.build_config }}
+        run: ctest --test-dir build --build-config ${{ steps.vars.outputs.build_config }} --output-on-failure
 {%- endraw %}


### PR DESCRIPTION
This makes it easier to debug unit test failures.

This commit also addresses a benign issue where "Default" was being erroneously passed through as a CMake parameter.