### PR TITLE
Run sanitizer checks in release mode

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -42,8 +42,8 @@ jobs:
                   "tests": [
                     { "stdlibs": ["libstdc++"],
                       "tests": [
-                        "Debug.Default", "Release.Default", "Debug.TSan", "Debug.MaxSan",
-                        "Debug.Werror", "Debug.Dynamic"
+                        "Debug.Default", "Release.Default", "Release.TSan",
+                        "Release.MaxSan", "Debug.Werror", "Debug.Dynamic"
                       ]
                     }
                   ]
@@ -76,8 +76,8 @@ jobs:
                   "tests": [
                     { "stdlibs": ["libstdc++", "libc++"],
                       "tests": [
-                        "Debug.Default", "Release.Default", "Debug.TSan", "Debug.MaxSan",
-                        "Debug.Werror", "Debug.Dynamic"
+                        "Debug.Default", "Release.Default", "Release.TSan",
+                        "Release.MaxSan", "Debug.Werror", "Debug.Dynamic"
                       ]
                     }
                   ]
@@ -128,7 +128,7 @@ jobs:
                 { "cxxversions": ["c++23"],
                   "tests": [
                     { "stdlibs": ["stl"],
-                      "tests": ["Debug.Default", "Release.Default", "Debug.MaxSan"]
+                      "tests": ["Debug.Default", "Release.Default", "Release.MaxSan"]
                     }
                   ]
                 }

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
@@ -42,8 +42,8 @@ jobs:
                   "tests": [
                     { "stdlibs": ["libstdc++"],
                       "tests": [
-                        "Debug.Default", "Release.Default", "Debug.TSan", "Debug.MaxSan",
-                        "Debug.Werror", "Debug.Dynamic"
+                        "Debug.Default", "Release.Default", "Release.TSan",
+                        "Release.MaxSan", "Debug.Werror", "Debug.Dynamic"
                       ]
                     }
                   ]
@@ -76,8 +76,8 @@ jobs:
                   "tests": [
                     { "stdlibs": ["libstdc++", "libc++"],
                       "tests": [
-                        "Debug.Default", "Release.Default", "Debug.TSan", "Debug.MaxSan",
-                        "Debug.Werror", "Debug.Dynamic"
+                        "Debug.Default", "Release.Default", "Release.TSan",
+                        "Release.MaxSan", "Debug.Werror", "Debug.Dynamic"
                       ]
                     }
                   ]
@@ -128,7 +128,7 @@ jobs:
                 { "cxxversions": ["c++23"],
                   "tests": [
                     { "stdlibs": ["stl"],
-                      "tests": ["Debug.Default", "Release.Default", "Debug.MaxSan"]
+                      "tests": ["Debug.Default", "Release.Default", "Release.MaxSan"]
                     }
                   ]
                 }


### PR DESCRIPTION
As suggested by Steve Downey at the 2025-07-07 Beman Sync, sanitizer checks are more effective in release mode because they are more likely to flag unexpected code paths resulting from compiler optimizations.