### PR TITLE
Fix cron for pre-commit auto-update

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '30 15 * * *'
-    - cron: "0 0 * * 0"
+    - cron: "0 16 * * 0"
 
 jobs:
   beman-submodule-check:

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '30 15 * * *'
-    - cron: "0 0 * * 0"
+    - cron: "0 16 * * 0"
 
 jobs:
   beman-submodule-check:


### PR DESCRIPTION
Previously, the cron schedule intended for use by pre-commit auto-update did not match the if condition for that job. This fix brings them into alignment.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
