### PR TITLE
Work around lack of support for relative paths in CMAKE_PREFIX_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ cmake \
   -B build \
   -S . \
   -DCMAKE_CXX_STANDARD=20 \
-  -DCMAKE_PREFIX_PATH=./infra/cmake \
+  -DCMAKE_PREFIX_PATH=$PWD/infra/cmake \
   # Your extra arguments here.
 cmake --build build
 ctest --test-dir build

--- a/cookiecutter/{{cookiecutter.project_name}}/README.md
+++ b/cookiecutter/{{cookiecutter.project_name}}/README.md
@@ -246,7 +246,7 @@ cmake \
   -B build \
   -S . \
   -DCMAKE_CXX_STANDARD=20 \
-  -DCMAKE_PREFIX_PATH=./infra/cmake \
+  -DCMAKE_PREFIX_PATH=$PWD/infra/cmake \
   # Your extra arguments here.
 cmake --build build
 ctest --test-dir build


### PR DESCRIPTION
Due to https://gitlab.kitware.com/cmake/cmake/-/issues/16644, the command in the README explaining how to manually build exemplar was broken. This patch works around the issue by using the $PWD builtin shell variable to change it to an absolute path.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
