### PR TITLE
Add unit test for CMake installation

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -13,10 +13,10 @@ on:
 
 jobs:
   beman-submodule-check:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@1.1.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@1.2.1
 
   preset-test:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-preset-test.yml@1.1.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-preset-test.yml@1.2.1
     with:
       matrix_config: >
         [
@@ -31,7 +31,7 @@ jobs:
         ]
 
   build-and-test:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-build-and-test.yml@1.1.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-build-and-test.yml@1.2.1
     with:
       matrix_config: >
         {
@@ -134,7 +134,14 @@ jobs:
           ]
         }
 
+  install-test:
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-install-test.yml@1.2.1
+    with:
+      image: ghcr.io/bemanproject/infra-containers-gcc:latest
+      cxx_standard: 26
+      main_header: identity.hpp
+
   create-issue-when-fault:
     needs: [preset-test, build-and-test]
     if: failure() && github.event_name == 'schedule'
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.1.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.2.1

--- a/.github/workflows/pre-commit-check.yml
+++ b/.github/workflows/pre-commit-check.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   pre-commit:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-pre-commit.yml@1.1.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-pre-commit.yml@1.2.1

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   auto-update-pre-commit:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-update-pre-commit.yml@1.1.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-update-pre-commit.yml@1.2.1
     secrets:
       APP_ID: ${{ secrets.AUTO_PR_BOT_APP_ID }}
       PRIVATE_KEY: ${{ secrets.AUTO_PR_BOT_PRIVATE_KEY }}

--- a/cookiecutter/cookiecutter.json
+++ b/cookiecutter/cookiecutter.json
@@ -6,7 +6,7 @@
   "description": "Short project description.",
   "godbolt_link": "https://www.example.com",
   "_copy_without_render": [
-    "infra",
-    ".github/workflows"
-  ]
+    "infra"
+  ],
+  "_jinja2_env_vars": {"trim_blocks": true}
 }

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
@@ -13,10 +13,10 @@ on:
 
 jobs:
   beman-submodule-check:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@1.1.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@1.2.1
 
   preset-test:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-preset-test.yml@1.1.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-preset-test.yml@1.2.1
     with:
       matrix_config: >
         [
@@ -31,7 +31,7 @@ jobs:
         ]
 
   build-and-test:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-build-and-test.yml@1.1.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-build-and-test.yml@1.2.1
     with:
       matrix_config: >
         {
@@ -134,7 +134,16 @@ jobs:
           ]
         }
 
+  install-test:
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-install-test.yml@1.2.1
+    with:
+      image: ghcr.io/bemanproject/infra-containers-gcc:latest
+      cxx_standard: 26
+{% if cookiecutter.project_name == "exemplar" %}
+      main_header: identity.hpp
+{% endif %}
+
   create-issue-when-fault:
     needs: [preset-test, build-and-test]
     if: failure() && github.event_name == 'schedule'
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.1.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.2.1

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit-check.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit-check.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   pre-commit:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-pre-commit.yml@1.1.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-pre-commit.yml@1.2.1

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit-update.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit-update.yml
@@ -7,9 +7,12 @@ on:
   schedule:
     - cron: "0 16 * * 0"
 
+{% raw -%}
 jobs:
   auto-update-pre-commit:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-update-pre-commit.yml@1.1.0
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-update-pre-commit.yml@1.2.1
     secrets:
       APP_ID: ${{ secrets.AUTO_PR_BOT_APP_ID }}
       PRIVATE_KEY: ${{ secrets.AUTO_PR_BOT_PRIVATE_KEY }}
+{%- endraw %}
+


### PR DESCRIPTION
This makes use of the new reusable GitHub Actions workflow added by infra-workflows commit 65cf13a216d835190d8da70d456a1307431373eb. It tests whether, when the library is installed, it can be picked up by CMake in a consumer project, and whether that project can successfully build a main.cpp file that includes identity.hpp.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
