### PR TITLE
Adjust CI to remove broken Clang 18/C++26/libstdc++ unit test

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -90,7 +90,7 @@ jobs:
                 }
               ]
             },
-            { "versions": ["20", "19", "18"],
+            { "versions": ["20", "19"],
               "tests": [
                 { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
                   "tests": [
@@ -99,7 +99,7 @@ jobs:
                 }
               ]
             },
-            { "versions": ["17"],
+            { "versions": ["18", "17"],
               "tests": [
                 { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
                   "tests": [{"stdlibs": ["libc++"], "tests": ["Release.Default"]}]

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
@@ -90,7 +90,7 @@ jobs:
                 }
               ]
             },
-            { "versions": ["20", "19", "18"],
+            { "versions": ["20", "19"],
               "tests": [
                 { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
                   "tests": [
@@ -99,7 +99,7 @@ jobs:
                 }
               ]
             },
-            { "versions": ["17"],
+            { "versions": ["18", "17"],
               "tests": [
                 { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
                   "tests": [{"stdlibs": ["libc++"], "tests": ["Release.Default"]}]


### PR DESCRIPTION
This test stopped working after the Clang 18 CI image was updated, I believe because the libstdc++ version was bumped from version 14 to version 15.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
