### PR TITLE
Fix required CMake version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Full runnable examples can be found in [`examples/`](examples/).
 This project requires at least the following to build:
 
 * A C++ compiler that conforms to the C++17 standard or greater
-* CMake 3.25 or later
+* CMake 3.28 or later
 * (Test Only) GoogleTest
 
 You can disable building tests by setting CMake option

--- a/cookiecutter/{{cookiecutter.project_name}}/README.md
+++ b/cookiecutter/{{cookiecutter.project_name}}/README.md
@@ -91,7 +91,7 @@ Full runnable examples can be found in [`examples/`](examples/).
 This project requires at least the following to build:
 
 * A C++ compiler that conforms to the C++17 standard or greater
-* CMake 3.25 or later
+* CMake 3.28 or later
 * (Test Only) GoogleTest
 
 You can disable building tests by setting CMake option


### PR DESCRIPTION
We require 3.28 but the README stated 3.25 instead.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
