### PR TITLE
Bump infra submodule to latest

### DIFF
--- a/cookiecutter/{{cookiecutter.project_name}}/infra/.beman_submodule
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/.beman_submodule
@@ -1,3 +1,3 @@
 [beman_submodule]
 remote=https://github.com/bemanproject/infra.git
-commit_hash=9f89e813b844915267b783289d386a09c69560d1
+commit_hash=b3545a45640abd1fedc01441ca3f220d9ac5a8e3

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/beman-install-library-config.cmake
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/beman-install-library-config.cmake
@@ -84,8 +84,8 @@ function(beman_install_library name)
 
     option(
         ${project_prefix}_INSTALL_CONFIG_FILE_PACKAGE
-        "Enable building examples. Default: ${PROJECT_IS_TOP_LEVEL}. Values: { ON, OFF }."
-        ${PROJECT_IS_TOP_LEVEL}
+        "Enable creating and installing a CMake config-file package. Default: ON. Values: { ON, OFF }."
+        ON
     )
 
     # By default, install the config package

--- a/infra/.beman_submodule
+++ b/infra/.beman_submodule
@@ -1,3 +1,3 @@
 [beman_submodule]
 remote=https://github.com/bemanproject/infra.git
-commit_hash=9f89e813b844915267b783289d386a09c69560d1
+commit_hash=b3545a45640abd1fedc01441ca3f220d9ac5a8e3

--- a/infra/cmake/beman-install-library-config.cmake
+++ b/infra/cmake/beman-install-library-config.cmake
@@ -84,8 +84,8 @@ function(beman_install_library name)
 
     option(
         ${project_prefix}_INSTALL_CONFIG_FILE_PACKAGE
-        "Enable building examples. Default: ${PROJECT_IS_TOP_LEVEL}. Values: { ON, OFF }."
-        ${PROJECT_IS_TOP_LEVEL}
+        "Enable creating and installing a CMake config-file package. Default: ON. Values: { ON, OFF }."
+        ON
     )
 
     # By default, install the config package


### PR DESCRIPTION
This pulls in
https://github.com/bemanproject/infra/commit/b3545a45640abd1fedc01441ca3f220d9ac5a8e3, which fixes the use of beman projects as dependencies.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
