### PR TITLE
Remove duplicative find_package call for beman-install-library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@ include(infra/cmake/beman-install-library-config.cmake)
 
 add_subdirectory(src/beman/exemplar)
 
-find_package(beman-install-library REQUIRED)
 beman_install_library(beman.exemplar)
 
 if(BEMAN_EXEMPLAR_BUILD_TESTS)

--- a/cookiecutter/{{cookiecutter.project_name}}/CMakeLists.txt
+++ b/cookiecutter/{{cookiecutter.project_name}}/CMakeLists.txt
@@ -29,7 +29,6 @@ include(infra/cmake/beman-install-library-config.cmake)
 
 add_subdirectory(src/beman/{{cookiecutter.project_name}})
 
-find_package(beman-install-library REQUIRED)
 beman_install_library(beman.{{cookiecutter.project_name}})
 
 if(BEMAN_{{cookiecutter.project_name.upper()}}_BUILD_TESTS)


### PR DESCRIPTION
Since df40a6da471533585e866826b69a4e2f8ffbecdb, we directly include the vendored CMake file that provides the beman_install_library function, but that commit did not remove the find_package call.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
