### PR TITLE
VERIFY_INTERFACE_HEADER_SETS only if PROJECT_IS_TOP_LEVEL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,10 @@ target_sources(
     PUBLIC FILE_SET HEADERS BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
-set_target_properties(beman.exemplar PROPERTIES VERIFY_INTERFACE_HEADER_SETS ON)
+set_target_properties(
+    beman.exemplar
+    PROPERTIES VERIFY_INTERFACE_HEADER_SETS ${PROJECT_IS_TOP_LEVEL}
+)
 
 add_subdirectory(include/beman/exemplar)
 

--- a/cookiecutter/{{cookiecutter.project_name}}/CMakeLists.txt
+++ b/cookiecutter/{{cookiecutter.project_name}}/CMakeLists.txt
@@ -39,7 +39,10 @@ target_sources(
     PUBLIC FILE_SET HEADERS BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
-set_target_properties(beman.{{cookiecutter.project_name}} PROPERTIES VERIFY_INTERFACE_HEADER_SETS ON)
+set_target_properties(
+    beman.{{cookiecutter.project_name}}
+    PROPERTIES VERIFY_INTERFACE_HEADER_SETS ${PROJECT_IS_TOP_LEVEL}
+)
 
 add_subdirectory(include/beman/{{cookiecutter.project_name}})
 {% if cookiecutter.library_type == "static" %}


### PR DESCRIPTION
### see targets list of `ninja help` on `beman.net` project:

```
beman.execution: phony
beman.execution_headers: phony
beman.execution_headers_verify_interface_header_sets: phony
beman.net_headers: phony
beman.net_headers_verify_interface_header_sets: phony
beman.task: phony
beman.task_headers: phony
beman.task_headers_verify_interface_header_sets: phony
libbeman.execution.a: phony
libbeman.task.a: phony
sorted_list.pass: phony
```

see https://discourse.bemanproject.org/t/the-verify-interface-header-sets-must-not-always-enabled/560
