### PR TITLE
Bump cmake_minimum_required version to 3.30..4.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.28...4.2)
+cmake_minimum_required(VERSION 3.30...4.3)
 
 project(
     beman.exemplar # CMake Project Name, which is also the name of the top-level

--- a/cookiecutter/{{cookiecutter.project_name}}/CMakeLists.txt
+++ b/cookiecutter/{{cookiecutter.project_name}}/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.28...4.2)
+cmake_minimum_required(VERSION 3.30...4.3)
 
 project(
     beman.{{cookiecutter.project_name}} # CMake Project Name, which is also the name of the top-level


### PR DESCRIPTION
This brings exemplar into alignment with what execution currently uses and is required for import std; support.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
