### PR TITLE
Remove install-test from CI tests

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -134,13 +134,6 @@ jobs:
           ]
         }
 
-  install-test:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-install-test.yml@1.3.0
-    with:
-      image: ghcr.io/bemanproject/infra-containers-gcc:latest
-      cxx_standard: 26
-      main_header: identity.hpp
-
   create-issue-when-fault:
     needs: [preset-test, build-and-test]
     if: failure() && github.event_name == 'schedule'

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
@@ -136,15 +136,6 @@ jobs:
           ]
         }
 
-  install-test:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-install-test.yml@1.3.0
-    with:
-      image: ghcr.io/bemanproject/infra-containers-gcc:latest
-      cxx_standard: 26
-{% if cookiecutter.project_name == "exemplar" %}
-      main_header: identity.hpp
-{% endif %}
-
   create-issue-when-fault:
     needs: [preset-test, build-and-test]
     if: failure() && github.event_name == 'schedule'


### PR DESCRIPTION
As evidenced by testing this with utf_view, which depends on transform_view, this test does not work properly if a library has dependencies that need to be installed. This commit removes it; in the future, a new implementation of this test using vcpkg will be developed.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
