### PR TITLE
Bump actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/catch2_exemplar_test.yml
+++ b/.github/workflows/catch2_exemplar_test.yml
@@ -14,7 +14,7 @@ jobs:
     name: "Catch2 exemplar smoke test"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Test catch2 exemplar
         run: |
           cd cookiecutter

--- a/.github/workflows/cookiecutter_test.yml
+++ b/.github/workflows/cookiecutter_test.yml
@@ -13,7 +13,7 @@ jobs:
     name: "Check cookiecutter for consistency"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: beman cookiecutter consistency check
         run: |
           ./cookiecutter/check_cookiecutter.sh

--- a/.github/workflows/static_exemplar_test.yml
+++ b/.github/workflows/static_exemplar_test.yml
@@ -14,7 +14,7 @@ jobs:
     name: "Static exemplar smoke test"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Test static exemplar
         run: |
           cd cookiecutter

--- a/.github/workflows/todo_exemplar_test.yml
+++ b/.github/workflows/todo_exemplar_test.yml
@@ -14,7 +14,7 @@ jobs:
     name: "TODO exemplar smoke test"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Test static exemplar
         run: |
           cd cookiecutter


### PR DESCRIPTION
This fixes an issue with Node v20 deprecation.

This only affects the exemplar-specific CI tests, not the CI tests that also run for the cookiecutter-stamped repositories, which are managed by the bemanproject/infra-workflows repository and had the corresponding update applied in commit
53d873e6e38019a5f000390311c73ff85f5c1cb2.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
