### PR TITLE
Add support for build telemetry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,9 @@ option(
     ${PROJECT_IS_TOP_LEVEL}
 )
 
-# for find of beman-install-library
+# for find of beman_install_library and configure_build_telemetry
 include(infra/cmake/beman-install-library.cmake)
+include(infra/cmake/BuildTelemetryConfig.cmake)
 
 add_library(beman.exemplar INTERFACE)
 add_library(beman::exemplar ALIAS beman.exemplar)
@@ -43,6 +44,7 @@ set_target_properties(
 add_subdirectory(include/beman/exemplar)
 
 beman_install_library(beman.exemplar TARGETS beman.exemplar)
+configure_build_telemetry()
 
 if(BEMAN_EXEMPLAR_BUILD_TESTS)
     enable_testing()

--- a/cookiecutter/{{cookiecutter.project_name}}/CMakeLists.txt
+++ b/cookiecutter/{{cookiecutter.project_name}}/CMakeLists.txt
@@ -24,8 +24,9 @@ option(
     ${PROJECT_IS_TOP_LEVEL}
 )
 
-# for find of beman-install-library
+# for find of beman_install_library and configure_build_telemetry
 include(infra/cmake/beman-install-library.cmake)
+include(infra/cmake/BuildTelemetryConfig.cmake)
 
 {% if cookiecutter.library_type == "interface" %}
 add_library(beman.{{cookiecutter.project_name}} INTERFACE)
@@ -50,6 +51,7 @@ add_subdirectory(src/beman/{{cookiecutter.project_name}})
 {% endif %}
 
 beman_install_library(beman.{{cookiecutter.project_name}} TARGETS beman.{{cookiecutter.project_name}})
+configure_build_telemetry()
 
 if(BEMAN_{{cookiecutter.project_name.upper()}}_BUILD_TESTS)
     enable_testing()

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/.beman_submodule
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/.beman_submodule
@@ -1,3 +1,3 @@
 [beman_submodule]
 remote=https://github.com/bemanproject/infra.git
-commit_hash=54dcdad8b661a405a6ac06453f0f06da5d30ba5c
+commit_hash=dfdb103b5fc9cccd3424c377130e318466f1dd89

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/.pre-commit-config.yaml
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ repos:
     -   id: check-added-large-files
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
 
     # CMake linting and formatting
-  - repo: https://github.com/BlankSpruce/gersemi
-    rev: 0.22.3
+  - repo: https://github.com/BlankSpruce/gersemi-pre-commit
+    rev: 0.27.2
     hooks:
     - id: gersemi
       name: CMake linting

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/README.md
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/README.md
@@ -52,3 +52,37 @@ Some options for the project and target will also be supported:
 * `BEMAN_INSTALL_CONFIG_FILE_PACKAGES` - a list of package names (e.g., `beman.something`) for which to install the config file
   (default: all packages)
 * `<BEMAN_NAME>_INSTALL_CONFIG_FILE_PACKAGE` - a per-project option to enable/disable config file installation (default: `ON` if the project is top-level, `OFF` otherwise). For instance for `beman.something`, the option would be `BEMAN_SOMETHING_INSTALL_CONFIG_FILE_PACKAGE`.
+
+# BuildTelemetry
+
+The cmake modules in this library provide access to CMake instrumentation data in Google Trace format which is visualizable with chrome://tracing and https://ui.perfetto.dev.
+
+Telemetry may be enabled in several ways:
+
+## `include`
+
+```cmake
+include (infra/cmake/BuildTelemetry.cmake)
+configure_build_telemetry()
+```
+
+## `find_package`
+
+```cmake
+find_package(BuildTelemetry)
+configure_build_telemetry()
+```
+
+as long as [BuildTelemetryConfig.cmake](./cmake/BuildTelemetryConfig.cmake) is in your module path.
+
+## `CMAKE_PROJECT_TOP_LEVEL_INCLUDES`
+A non-invasive way to inject this telemetry into a CMake build you do not want to modify.
+Add:
+```sh
+-DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=infra/cmake/BuildTelemetry.cmake
+```
+To the cmake invocation.
+
+In any form, CMake will call `telemetry.sh` which will copy the trace data in json format into a `.trace` subdirectory within the build directory.
+
+Multiple calls to `configure_build_telemetry` will only configure the callback hooks once, so it is safe to enable multiple times, including by TOP_LEVEL_INCLUDE.

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/BuildTelemetry.cmake
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/BuildTelemetry.cmake
@@ -1,0 +1,4 @@
+include_guard(GLOBAL)
+
+include(${CMAKE_CURRENT_LIST_DIR}/BuildTelemetryConfig.cmake)
+configure_build_telemetry()

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/BuildTelemetryConfig.cmake
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/BuildTelemetryConfig.cmake
@@ -1,0 +1,58 @@
+include_guard(GLOBAL)
+
+set(BUILD_TELEMETRY_DIR ${CMAKE_CURRENT_LIST_DIR})
+
+function(configure_build_telemetry)
+    if(NOT BUILD_TELEMETRY_CONFIGURATION)
+        # Check if the CMake version is at least 4.3
+        if(CMAKE_VERSION VERSION_LESS "4.3")
+            message(
+                STATUS
+                "CMake version is less than 4.3, configuring cmake_instrumentation is unavailable."
+            )
+            return()
+        else()
+            message(STATUS "Configuring Build Telemetry")
+        endif()
+
+        # Find bash and jq for the telemetry callback script.
+        # On Windows, Git for Windows provides bash if available.
+        find_program(BEMAN_BASH bash)
+        find_program(BEMAN_JQ jq)
+        if(NOT BEMAN_BASH OR NOT BEMAN_JQ)
+            message(
+                STATUS
+                "bash or jq not found, build telemetry disabled on this platform."
+            )
+            return()
+        endif()
+
+        # Telemetry query
+        cmake_instrumentation(
+            API_VERSION 1
+            DATA_VERSION 1
+            OPTIONS staticSystemInformation dynamicSystemInformation trace
+            HOOKS
+                postGenerate
+                preBuild
+                postBuild
+                preCMakeBuild
+                postCMakeBuild
+                postCMakeInstall
+                postCTest
+            CALLBACK ${BEMAN_BASH}
+            ${BUILD_TELEMETRY_DIR}/telemetry.sh
+        )
+        message(
+            DEBUG
+            "using callback script ${BUILD_TELEMETRY_DIR}/telemetry.sh via ${BEMAN_BASH}"
+        )
+
+        # Mark configuration as done in cache
+        set(BUILD_TELEMETRY_CONFIGURATION
+            TRUE
+            CACHE INTERNAL
+            "Flag to ensure Build Telemetry configured only once"
+        )
+    endif()
+endfunction(configure_build_telemetry)

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/Config.cmake.in
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/Config.cmake.in
@@ -3,10 +3,10 @@
 
 include(CMakeFindDependencyMacro)
 
-@BEMAN_FIND_DEPENDENCIES@
+@BEMAN_INSTALL_FIND_DEPENDENCIES@
 
 @PACKAGE_INIT@
 
-include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/@BEMAN_INSTALL_BASE_PKG_NAME@-targets.cmake)
 
-check_required_components(@PROJECT_NAME@)
+check_required_components(@BEMAN_INSTALL_BASE_PKG_NAME@)

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/beman-install-library.cmake
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/beman-install-library.cmake
@@ -86,14 +86,14 @@ function(beman_install_library name)
     set(multiValueArgs TARGETS DEPENDENCIES)
 
     cmake_parse_arguments(
-        BEMAN
+        BEMAN_INSTALL
         "${options}"
         "${oneValueArgs}"
         "${multiValueArgs}"
         ${ARGN}
     )
 
-    if(NOT BEMAN_TARGETS)
+    if(NOT BEMAN_INSTALL_TARGETS)
         message(
             FATAL_ERROR
             "beman_install_library(${name}): TARGETS must be specified"
@@ -103,7 +103,7 @@ function(beman_install_library name)
     if(CMAKE_SKIP_INSTALL_RULES)
         message(
             WARNING
-            "beman_install_library(${name}): not installing targets '${BEMAN_TARGETS}' due to CMAKE_SKIP_INSTALL_RULES"
+            "beman_install_library(${name}): not installing targets '${BEMAN_INSTALL_TARGETS}' due to CMAKE_SKIP_INSTALL_RULES"
         )
         return()
     endif()
@@ -113,16 +113,16 @@ function(beman_install_library name)
     # ----------------------------
     # Defaults
     # ----------------------------
-    if(NOT BEMAN_NAMESPACE)
-        set(BEMAN_NAMESPACE "beman::")
+    if(NOT BEMAN_INSTALL_NAMESPACE)
+        set(BEMAN_INSTALL_NAMESPACE "beman::")
     endif()
 
-    if(NOT BEMAN_EXPORT_NAME)
-        set(BEMAN_EXPORT_NAME "${name}-targets")
+    if(NOT BEMAN_INSTALL_EXPORT_NAME)
+        set(BEMAN_INSTALL_EXPORT_NAME "${name}-targets")
     endif()
 
-    if(NOT BEMAN_DESTINATION)
-        set(BEMAN_DESTINATION "${_config_install_dir}/modules")
+    if(NOT BEMAN_INSTALL_DESTINATION)
+        set(BEMAN_INSTALL_DESTINATION "${_config_install_dir}/modules")
     endif()
 
     string(REPLACE "beman." "" install_component_name "${name}")
@@ -134,7 +134,7 @@ function(beman_install_library name)
     # --------------------------------------------------
     # Install each target with all of its file sets
     # --------------------------------------------------
-    foreach(_tgt IN LISTS BEMAN_TARGETS)
+    foreach(_tgt IN LISTS BEMAN_INSTALL_TARGETS)
         if(NOT TARGET "${_tgt}")
             message(
                 WARNING
@@ -177,8 +177,7 @@ function(beman_install_library name)
             )
             foreach(_install_header_set IN LISTS _available_header_sets)
                 list(
-                    APPEND
-                    _install_header_set_args
+                    APPEND _install_header_set_args
                     FILE_SET
                     "${_install_header_set}"
                     COMPONENT
@@ -198,7 +197,7 @@ function(beman_install_library name)
             )
             install(
                 TARGETS "${_tgt}"
-                EXPORT ${BEMAN_EXPORT_NAME}
+                EXPORT ${BEMAN_INSTALL_EXPORT_NAME}
                 ARCHIVE COMPONENT "${install_component_name}_Development"
                 LIBRARY
                     COMPONENT "${install_component_name}_Runtime"
@@ -206,7 +205,7 @@ function(beman_install_library name)
                 RUNTIME COMPONENT "${install_component_name}_Runtime"
                 ${_install_header_set_args}
                 FILE_SET ${_module_sets}
-                    DESTINATION "${BEMAN_DESTINATION}"
+                    DESTINATION "${BEMAN_INSTALL_DESTINATION}"
                     COMPONENT "${install_component_name}_Development"
                 # NOTE: There's currently no convention for this location! CK
                 CXX_MODULES_BMI
@@ -217,7 +216,7 @@ function(beman_install_library name)
         else()
             install(
                 TARGETS "${_tgt}"
-                EXPORT ${BEMAN_EXPORT_NAME}
+                EXPORT ${BEMAN_INSTALL_EXPORT_NAME}
                 ARCHIVE COMPONENT "${install_component_name}_Development"
                 LIBRARY
                     COMPONENT "${install_component_name}_Runtime"
@@ -233,8 +232,8 @@ function(beman_install_library name)
     # --------------------------------------------------
     # gersemi: off
     install(
-        EXPORT ${BEMAN_EXPORT_NAME}
-        NAMESPACE ${BEMAN_NAMESPACE}
+        EXPORT ${BEMAN_INSTALL_EXPORT_NAME}
+        NAMESPACE ${BEMAN_INSTALL_NAMESPACE}
         CXX_MODULES_DIRECTORY cxx-modules
         DESTINATION ${_config_install_dir}
         COMPONENT "${install_component_name}_Development"
@@ -279,19 +278,20 @@ function(beman_install_library name)
     # expand dependencies
     # ----------------------------------------
     set(_beman_find_deps "")
-    foreach(dep IN LISTS BEMAN_DEPENDENCIES)
+    foreach(dep IN LISTS BEMAN_INSTALL_DEPENDENCIES)
         message(
             VERBOSE
             "beman-install-library(${name}): Add find_dependency(${dep})"
         )
         string(APPEND _beman_find_deps "find_dependency(${dep})\n")
     endforeach()
-    set(BEMAN_FIND_DEPENDENCIES "${_beman_find_deps}")
+    set(BEMAN_INSTALL_FIND_DEPENDENCIES "${_beman_find_deps}")
 
     # ----------------------------------------
     # Generate + install config files
     # ----------------------------------------
     if(_install_config)
+        set(BEMAN_INSTALL_BASE_PKG_NAME ${name})
         configure_package_config_file(
             "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/Config.cmake.in"
             "${CMAKE_CURRENT_BINARY_DIR}/${name}-config.cmake"

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/telemetry.sh
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/telemetry.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+trap 'echo "Aborting due to errexit on line $LINENO. Exit code: $?" >&2' ERR
+set -o errtrace
+set -o pipefail
+IFS=$'\n\t'
+
+###############################################################################
+# Environment
+###############################################################################
+
+# $_ME
+#
+# This program's basename.
+_ME="$(basename "${0}")"
+
+###############################################################################
+# Help
+###############################################################################
+
+# _print_help()
+#
+# Usage:
+#   _print_help
+#
+# Print the program help information.
+_print_help() {
+    cat <<HEREDOC
+
+Callback script to process CMake Insrumentation data
+https://cmake.org/cmake/help/latest/command/cmake_instrumentation.html
+
+Usage:
+  ${_ME} [<arguments>]
+  ${_ME} -h | --help
+
+Options:
+  -h --help  Show this screen.
+
+Environment:
+  Setting DEBUG_TELEMETRY in the environment will enable DEBUG logging
+HEREDOC
+}
+
+###############################################################################
+# Program Functions
+###############################################################################
+_debug_print() {
+    if [[ -n "${DEBUG_TELEMETRY:-}" ]]; then
+        printf "[DEBUG] $(date +'%H:%M:%S'): %s \n" "$1" >&2
+    fi
+}
+
+_check_file_exists() {
+    local file="$1"
+    if [[ ! -f "${file}" ]]; then
+        echo "Error: File not found: ${file}" >&2
+        exit 1  # Exit the entire script with a non-zero status
+    fi
+}
+
+_process_index() {
+    indexFile=${1:-}
+    _check_file_exists "${indexFile}"
+    _debug_print "$(cat "${indexFile}")"
+
+    local buildDir
+    buildDir=$(jq -r '.buildDir' "${1:-}")
+    _debug_print "$(printf "buildDir is |%q|" "${buildDir}")"
+
+    local dataDir
+    dataDir=$(jq -r '.dataDir' "${1:-}")
+    _debug_print "$(printf "dataDir is |%q|" "${dataDir}")"
+
+    local hook
+    hook=$(jq -r '.hook' "${1:-}")
+    _debug_print "$(printf "hook is |%q|" "${hook}")"
+
+    local trace
+    trace=$(jq -r '.trace' "${1:-}")
+    _debug_print "$(printf "trace is |%q|" "${trace}")"
+
+    local outputDir
+    outputDir="${buildDir}/.trace"
+    _debug_print "$(printf "Copy trace to |%q|" "${outputDir}")"
+    mkdir -p "${outputDir}"
+
+    local traceDestFile
+    traceDestFile="${outputDir}/${hook}-$(basename "${trace}")"
+    _debug_print "$(printf "traceDestFile: |%q|" "${traceDestFile}")"
+    cp "${dataDir}/${trace}" "${outputDir}/${hook}-$(basename "${trace}")"
+}
+
+###############################################################################
+# Main
+###############################################################################
+
+# _main()
+#
+# Usage:
+#   _main [<options>] [<arguments>]
+#
+# Description:
+#   Entry point for the program, handling basic option parsing and dispatching.
+_main() {
+    # Avoid complex option parsing when only one program option is expected.
+    if [[ "${1:-}" =~ ^-h|--help$  ]]
+    then
+        _print_help
+    else
+        _process_index "$@"
+    fi
+}
+
+# Call `_main` after everything has been defined.
+_main "$@"

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/use-fetch-content.cmake
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/use-fetch-content.cmake
@@ -15,8 +15,7 @@ message(TRACE "BemanExemplar_projectDir=\"${BemanExemplar_projectDir}\"")
 
 message(TRACE "BEMAN_EXEMPLAR_LOCKFILE=\"${BEMAN_EXEMPLAR_LOCKFILE}\"")
 file(
-    REAL_PATH
-    "${BEMAN_EXEMPLAR_LOCKFILE}"
+    REAL_PATH "${BEMAN_EXEMPLAR_LOCKFILE}"
     BemanExemplar_lockfile
     BASE_DIRECTORY "${BemanExemplar_projectDir}"
     EXPAND_TILDE
@@ -38,8 +37,7 @@ function(BemanExemplar_provideDependency method package_name)
 
     # Get the "dependencies" field and store it in BemanExemplar_dependenciesObj
     string(
-        JSON
-        BemanExemplar_dependenciesObj
+        JSON BemanExemplar_dependenciesObj
         ERROR_VARIABLE BemanExemplar_error
         GET "${BemanExemplar_rootObj}"
         "dependencies"
@@ -50,8 +48,7 @@ function(BemanExemplar_provideDependency method package_name)
 
     # Get the length of the libraries array and store it in BemanExemplar_dependenciesObj
     string(
-        JSON
-        BemanExemplar_numDependencies
+        JSON BemanExemplar_numDependencies
         ERROR_VARIABLE BemanExemplar_error
         LENGTH "${BemanExemplar_dependenciesObj}"
     )
@@ -73,8 +70,7 @@ function(BemanExemplar_provideDependency method package_name)
         # Get the dependency object at BemanExemplar_index
         # and store it in BemanExemplar_depObj
         string(
-            JSON
-            BemanExemplar_depObj
+            JSON BemanExemplar_depObj
             ERROR_VARIABLE BemanExemplar_error
             GET "${BemanExemplar_dependenciesObj}"
             "${BemanExemplar_index}"
@@ -88,8 +84,7 @@ function(BemanExemplar_provideDependency method package_name)
 
         # Get the "name" field and store it in BemanExemplar_name
         string(
-            JSON
-            BemanExemplar_name
+            JSON BemanExemplar_name
             ERROR_VARIABLE BemanExemplar_error
             GET "${BemanExemplar_depObj}"
             "name"
@@ -103,8 +98,7 @@ function(BemanExemplar_provideDependency method package_name)
 
         # Get the "package_name" field and store it in BemanExemplar_pkgName
         string(
-            JSON
-            BemanExemplar_pkgName
+            JSON BemanExemplar_pkgName
             ERROR_VARIABLE BemanExemplar_error
             GET "${BemanExemplar_depObj}"
             "package_name"
@@ -118,8 +112,7 @@ function(BemanExemplar_provideDependency method package_name)
 
         # Get the "git_repository" field and store it in BemanExemplar_repo
         string(
-            JSON
-            BemanExemplar_repo
+            JSON BemanExemplar_repo
             ERROR_VARIABLE BemanExemplar_error
             GET "${BemanExemplar_depObj}"
             "git_repository"
@@ -133,8 +126,7 @@ function(BemanExemplar_provideDependency method package_name)
 
         # Get the "git_tag" field and store it in BemanExemplar_tag
         string(
-            JSON
-            BemanExemplar_tag
+            JSON BemanExemplar_tag
             ERROR_VARIABLE BemanExemplar_error
             GET "${BemanExemplar_depObj}"
             "git_tag"
@@ -149,14 +141,12 @@ function(BemanExemplar_provideDependency method package_name)
         if(method STREQUAL "FIND_PACKAGE")
             if(package_name STREQUAL BemanExemplar_pkgName)
                 string(
-                    APPEND
-                    BemanExemplar_debug
+                    APPEND BemanExemplar_debug
                     "Redirecting find_package calls for ${BemanExemplar_pkgName} "
                     "to FetchContent logic.\n"
                 )
                 string(
-                    APPEND
-                    BemanExemplar_debug
+                    APPEND BemanExemplar_debug
                     "Fetching ${BemanExemplar_repo} at "
                     "${BemanExemplar_tag} according to ${BemanExemplar_lockfile}."
                 )
@@ -175,8 +165,7 @@ function(BemanExemplar_provideDependency method package_name)
                 # `include(Catch)` works.
                 if(BemanExemplar_pkgName STREQUAL "Catch2")
                     list(
-                        APPEND
-                        CMAKE_MODULE_PATH
+                        APPEND CMAKE_MODULE_PATH
                         "${${BemanExemplar_name}_SOURCE_DIR}/extras"
                     )
                     set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)

--- a/infra/.beman_submodule
+++ b/infra/.beman_submodule
@@ -1,3 +1,3 @@
 [beman_submodule]
 remote=https://github.com/bemanproject/infra.git
-commit_hash=54dcdad8b661a405a6ac06453f0f06da5d30ba5c
+commit_hash=dfdb103b5fc9cccd3424c377130e318466f1dd89

--- a/infra/.pre-commit-config.yaml
+++ b/infra/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ repos:
     -   id: check-added-large-files
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
 
     # CMake linting and formatting
-  - repo: https://github.com/BlankSpruce/gersemi
-    rev: 0.22.3
+  - repo: https://github.com/BlankSpruce/gersemi-pre-commit
+    rev: 0.27.2
     hooks:
     - id: gersemi
       name: CMake linting

--- a/infra/README.md
+++ b/infra/README.md
@@ -52,3 +52,37 @@ Some options for the project and target will also be supported:
 * `BEMAN_INSTALL_CONFIG_FILE_PACKAGES` - a list of package names (e.g., `beman.something`) for which to install the config file
   (default: all packages)
 * `<BEMAN_NAME>_INSTALL_CONFIG_FILE_PACKAGE` - a per-project option to enable/disable config file installation (default: `ON` if the project is top-level, `OFF` otherwise). For instance for `beman.something`, the option would be `BEMAN_SOMETHING_INSTALL_CONFIG_FILE_PACKAGE`.
+
+# BuildTelemetry
+
+The cmake modules in this library provide access to CMake instrumentation data in Google Trace format which is visualizable with chrome://tracing and https://ui.perfetto.dev.
+
+Telemetry may be enabled in several ways:
+
+## `include`
+
+```cmake
+include (infra/cmake/BuildTelemetry.cmake)
+configure_build_telemetry()
+```
+
+## `find_package`
+
+```cmake
+find_package(BuildTelemetry)
+configure_build_telemetry()
+```
+
+as long as [BuildTelemetryConfig.cmake](./cmake/BuildTelemetryConfig.cmake) is in your module path.
+
+## `CMAKE_PROJECT_TOP_LEVEL_INCLUDES`
+A non-invasive way to inject this telemetry into a CMake build you do not want to modify.
+Add:
+```sh
+-DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=infra/cmake/BuildTelemetry.cmake
+```
+To the cmake invocation.
+
+In any form, CMake will call `telemetry.sh` which will copy the trace data in json format into a `.trace` subdirectory within the build directory.
+
+Multiple calls to `configure_build_telemetry` will only configure the callback hooks once, so it is safe to enable multiple times, including by TOP_LEVEL_INCLUDE.

--- a/infra/cmake/BuildTelemetry.cmake
+++ b/infra/cmake/BuildTelemetry.cmake
@@ -1,0 +1,4 @@
+include_guard(GLOBAL)
+
+include(${CMAKE_CURRENT_LIST_DIR}/BuildTelemetryConfig.cmake)
+configure_build_telemetry()

--- a/infra/cmake/BuildTelemetryConfig.cmake
+++ b/infra/cmake/BuildTelemetryConfig.cmake
@@ -1,0 +1,58 @@
+include_guard(GLOBAL)
+
+set(BUILD_TELEMETRY_DIR ${CMAKE_CURRENT_LIST_DIR})
+
+function(configure_build_telemetry)
+    if(NOT BUILD_TELEMETRY_CONFIGURATION)
+        # Check if the CMake version is at least 4.3
+        if(CMAKE_VERSION VERSION_LESS "4.3")
+            message(
+                STATUS
+                "CMake version is less than 4.3, configuring cmake_instrumentation is unavailable."
+            )
+            return()
+        else()
+            message(STATUS "Configuring Build Telemetry")
+        endif()
+
+        # Find bash and jq for the telemetry callback script.
+        # On Windows, Git for Windows provides bash if available.
+        find_program(BEMAN_BASH bash)
+        find_program(BEMAN_JQ jq)
+        if(NOT BEMAN_BASH OR NOT BEMAN_JQ)
+            message(
+                STATUS
+                "bash or jq not found, build telemetry disabled on this platform."
+            )
+            return()
+        endif()
+
+        # Telemetry query
+        cmake_instrumentation(
+            API_VERSION 1
+            DATA_VERSION 1
+            OPTIONS staticSystemInformation dynamicSystemInformation trace
+            HOOKS
+                postGenerate
+                preBuild
+                postBuild
+                preCMakeBuild
+                postCMakeBuild
+                postCMakeInstall
+                postCTest
+            CALLBACK ${BEMAN_BASH}
+            ${BUILD_TELEMETRY_DIR}/telemetry.sh
+        )
+        message(
+            DEBUG
+            "using callback script ${BUILD_TELEMETRY_DIR}/telemetry.sh via ${BEMAN_BASH}"
+        )
+
+        # Mark configuration as done in cache
+        set(BUILD_TELEMETRY_CONFIGURATION
+            TRUE
+            CACHE INTERNAL
+            "Flag to ensure Build Telemetry configured only once"
+        )
+    endif()
+endfunction(configure_build_telemetry)

--- a/infra/cmake/Config.cmake.in
+++ b/infra/cmake/Config.cmake.in
@@ -3,10 +3,10 @@
 
 include(CMakeFindDependencyMacro)
 
-@BEMAN_FIND_DEPENDENCIES@
+@BEMAN_INSTALL_FIND_DEPENDENCIES@
 
 @PACKAGE_INIT@
 
-include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/@BEMAN_INSTALL_BASE_PKG_NAME@-targets.cmake)
 
-check_required_components(@PROJECT_NAME@)
+check_required_components(@BEMAN_INSTALL_BASE_PKG_NAME@)

--- a/infra/cmake/beman-install-library.cmake
+++ b/infra/cmake/beman-install-library.cmake
@@ -86,14 +86,14 @@ function(beman_install_library name)
     set(multiValueArgs TARGETS DEPENDENCIES)
 
     cmake_parse_arguments(
-        BEMAN
+        BEMAN_INSTALL
         "${options}"
         "${oneValueArgs}"
         "${multiValueArgs}"
         ${ARGN}
     )
 
-    if(NOT BEMAN_TARGETS)
+    if(NOT BEMAN_INSTALL_TARGETS)
         message(
             FATAL_ERROR
             "beman_install_library(${name}): TARGETS must be specified"
@@ -103,7 +103,7 @@ function(beman_install_library name)
     if(CMAKE_SKIP_INSTALL_RULES)
         message(
             WARNING
-            "beman_install_library(${name}): not installing targets '${BEMAN_TARGETS}' due to CMAKE_SKIP_INSTALL_RULES"
+            "beman_install_library(${name}): not installing targets '${BEMAN_INSTALL_TARGETS}' due to CMAKE_SKIP_INSTALL_RULES"
         )
         return()
     endif()
@@ -113,16 +113,16 @@ function(beman_install_library name)
     # ----------------------------
     # Defaults
     # ----------------------------
-    if(NOT BEMAN_NAMESPACE)
-        set(BEMAN_NAMESPACE "beman::")
+    if(NOT BEMAN_INSTALL_NAMESPACE)
+        set(BEMAN_INSTALL_NAMESPACE "beman::")
     endif()
 
-    if(NOT BEMAN_EXPORT_NAME)
-        set(BEMAN_EXPORT_NAME "${name}-targets")
+    if(NOT BEMAN_INSTALL_EXPORT_NAME)
+        set(BEMAN_INSTALL_EXPORT_NAME "${name}-targets")
     endif()
 
-    if(NOT BEMAN_DESTINATION)
-        set(BEMAN_DESTINATION "${_config_install_dir}/modules")
+    if(NOT BEMAN_INSTALL_DESTINATION)
+        set(BEMAN_INSTALL_DESTINATION "${_config_install_dir}/modules")
     endif()
 
     string(REPLACE "beman." "" install_component_name "${name}")
@@ -134,7 +134,7 @@ function(beman_install_library name)
     # --------------------------------------------------
     # Install each target with all of its file sets
     # --------------------------------------------------
-    foreach(_tgt IN LISTS BEMAN_TARGETS)
+    foreach(_tgt IN LISTS BEMAN_INSTALL_TARGETS)
         if(NOT TARGET "${_tgt}")
             message(
                 WARNING
@@ -177,8 +177,7 @@ function(beman_install_library name)
             )
             foreach(_install_header_set IN LISTS _available_header_sets)
                 list(
-                    APPEND
-                    _install_header_set_args
+                    APPEND _install_header_set_args
                     FILE_SET
                     "${_install_header_set}"
                     COMPONENT
@@ -198,7 +197,7 @@ function(beman_install_library name)
             )
             install(
                 TARGETS "${_tgt}"
-                EXPORT ${BEMAN_EXPORT_NAME}
+                EXPORT ${BEMAN_INSTALL_EXPORT_NAME}
                 ARCHIVE COMPONENT "${install_component_name}_Development"
                 LIBRARY
                     COMPONENT "${install_component_name}_Runtime"
@@ -206,7 +205,7 @@ function(beman_install_library name)
                 RUNTIME COMPONENT "${install_component_name}_Runtime"
                 ${_install_header_set_args}
                 FILE_SET ${_module_sets}
-                    DESTINATION "${BEMAN_DESTINATION}"
+                    DESTINATION "${BEMAN_INSTALL_DESTINATION}"
                     COMPONENT "${install_component_name}_Development"
                 # NOTE: There's currently no convention for this location! CK
                 CXX_MODULES_BMI
@@ -217,7 +216,7 @@ function(beman_install_library name)
         else()
             install(
                 TARGETS "${_tgt}"
-                EXPORT ${BEMAN_EXPORT_NAME}
+                EXPORT ${BEMAN_INSTALL_EXPORT_NAME}
                 ARCHIVE COMPONENT "${install_component_name}_Development"
                 LIBRARY
                     COMPONENT "${install_component_name}_Runtime"
@@ -233,8 +232,8 @@ function(beman_install_library name)
     # --------------------------------------------------
     # gersemi: off
     install(
-        EXPORT ${BEMAN_EXPORT_NAME}
-        NAMESPACE ${BEMAN_NAMESPACE}
+        EXPORT ${BEMAN_INSTALL_EXPORT_NAME}
+        NAMESPACE ${BEMAN_INSTALL_NAMESPACE}
         CXX_MODULES_DIRECTORY cxx-modules
         DESTINATION ${_config_install_dir}
         COMPONENT "${install_component_name}_Development"
@@ -279,19 +278,20 @@ function(beman_install_library name)
     # expand dependencies
     # ----------------------------------------
     set(_beman_find_deps "")
-    foreach(dep IN LISTS BEMAN_DEPENDENCIES)
+    foreach(dep IN LISTS BEMAN_INSTALL_DEPENDENCIES)
         message(
             VERBOSE
             "beman-install-library(${name}): Add find_dependency(${dep})"
         )
         string(APPEND _beman_find_deps "find_dependency(${dep})\n")
     endforeach()
-    set(BEMAN_FIND_DEPENDENCIES "${_beman_find_deps}")
+    set(BEMAN_INSTALL_FIND_DEPENDENCIES "${_beman_find_deps}")
 
     # ----------------------------------------
     # Generate + install config files
     # ----------------------------------------
     if(_install_config)
+        set(BEMAN_INSTALL_BASE_PKG_NAME ${name})
         configure_package_config_file(
             "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/Config.cmake.in"
             "${CMAKE_CURRENT_BINARY_DIR}/${name}-config.cmake"

--- a/infra/cmake/telemetry.sh
+++ b/infra/cmake/telemetry.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+trap 'echo "Aborting due to errexit on line $LINENO. Exit code: $?" >&2' ERR
+set -o errtrace
+set -o pipefail
+IFS=$'\n\t'
+
+###############################################################################
+# Environment
+###############################################################################
+
+# $_ME
+#
+# This program's basename.
+_ME="$(basename "${0}")"
+
+###############################################################################
+# Help
+###############################################################################
+
+# _print_help()
+#
+# Usage:
+#   _print_help
+#
+# Print the program help information.
+_print_help() {
+    cat <<HEREDOC
+
+Callback script to process CMake Insrumentation data
+https://cmake.org/cmake/help/latest/command/cmake_instrumentation.html
+
+Usage:
+  ${_ME} [<arguments>]
+  ${_ME} -h | --help
+
+Options:
+  -h --help  Show this screen.
+
+Environment:
+  Setting DEBUG_TELEMETRY in the environment will enable DEBUG logging
+HEREDOC
+}
+
+###############################################################################
+# Program Functions
+###############################################################################
+_debug_print() {
+    if [[ -n "${DEBUG_TELEMETRY:-}" ]]; then
+        printf "[DEBUG] $(date +'%H:%M:%S'): %s \n" "$1" >&2
+    fi
+}
+
+_check_file_exists() {
+    local file="$1"
+    if [[ ! -f "${file}" ]]; then
+        echo "Error: File not found: ${file}" >&2
+        exit 1  # Exit the entire script with a non-zero status
+    fi
+}
+
+_process_index() {
+    indexFile=${1:-}
+    _check_file_exists "${indexFile}"
+    _debug_print "$(cat "${indexFile}")"
+
+    local buildDir
+    buildDir=$(jq -r '.buildDir' "${1:-}")
+    _debug_print "$(printf "buildDir is |%q|" "${buildDir}")"
+
+    local dataDir
+    dataDir=$(jq -r '.dataDir' "${1:-}")
+    _debug_print "$(printf "dataDir is |%q|" "${dataDir}")"
+
+    local hook
+    hook=$(jq -r '.hook' "${1:-}")
+    _debug_print "$(printf "hook is |%q|" "${hook}")"
+
+    local trace
+    trace=$(jq -r '.trace' "${1:-}")
+    _debug_print "$(printf "trace is |%q|" "${trace}")"
+
+    local outputDir
+    outputDir="${buildDir}/.trace"
+    _debug_print "$(printf "Copy trace to |%q|" "${outputDir}")"
+    mkdir -p "${outputDir}"
+
+    local traceDestFile
+    traceDestFile="${outputDir}/${hook}-$(basename "${trace}")"
+    _debug_print "$(printf "traceDestFile: |%q|" "${traceDestFile}")"
+    cp "${dataDir}/${trace}" "${outputDir}/${hook}-$(basename "${trace}")"
+}
+
+###############################################################################
+# Main
+###############################################################################
+
+# _main()
+#
+# Usage:
+#   _main [<options>] [<arguments>]
+#
+# Description:
+#   Entry point for the program, handling basic option parsing and dispatching.
+_main() {
+    # Avoid complex option parsing when only one program option is expected.
+    if [[ "${1:-}" =~ ^-h|--help$  ]]
+    then
+        _print_help
+    else
+        _process_index "$@"
+    fi
+}
+
+# Call `_main` after everything has been defined.
+_main "$@"

--- a/infra/cmake/use-fetch-content.cmake
+++ b/infra/cmake/use-fetch-content.cmake
@@ -15,8 +15,7 @@ message(TRACE "BemanExemplar_projectDir=\"${BemanExemplar_projectDir}\"")
 
 message(TRACE "BEMAN_EXEMPLAR_LOCKFILE=\"${BEMAN_EXEMPLAR_LOCKFILE}\"")
 file(
-    REAL_PATH
-    "${BEMAN_EXEMPLAR_LOCKFILE}"
+    REAL_PATH "${BEMAN_EXEMPLAR_LOCKFILE}"
     BemanExemplar_lockfile
     BASE_DIRECTORY "${BemanExemplar_projectDir}"
     EXPAND_TILDE
@@ -38,8 +37,7 @@ function(BemanExemplar_provideDependency method package_name)
 
     # Get the "dependencies" field and store it in BemanExemplar_dependenciesObj
     string(
-        JSON
-        BemanExemplar_dependenciesObj
+        JSON BemanExemplar_dependenciesObj
         ERROR_VARIABLE BemanExemplar_error
         GET "${BemanExemplar_rootObj}"
         "dependencies"
@@ -50,8 +48,7 @@ function(BemanExemplar_provideDependency method package_name)
 
     # Get the length of the libraries array and store it in BemanExemplar_dependenciesObj
     string(
-        JSON
-        BemanExemplar_numDependencies
+        JSON BemanExemplar_numDependencies
         ERROR_VARIABLE BemanExemplar_error
         LENGTH "${BemanExemplar_dependenciesObj}"
     )
@@ -73,8 +70,7 @@ function(BemanExemplar_provideDependency method package_name)
         # Get the dependency object at BemanExemplar_index
         # and store it in BemanExemplar_depObj
         string(
-            JSON
-            BemanExemplar_depObj
+            JSON BemanExemplar_depObj
             ERROR_VARIABLE BemanExemplar_error
             GET "${BemanExemplar_dependenciesObj}"
             "${BemanExemplar_index}"
@@ -88,8 +84,7 @@ function(BemanExemplar_provideDependency method package_name)
 
         # Get the "name" field and store it in BemanExemplar_name
         string(
-            JSON
-            BemanExemplar_name
+            JSON BemanExemplar_name
             ERROR_VARIABLE BemanExemplar_error
             GET "${BemanExemplar_depObj}"
             "name"
@@ -103,8 +98,7 @@ function(BemanExemplar_provideDependency method package_name)
 
         # Get the "package_name" field and store it in BemanExemplar_pkgName
         string(
-            JSON
-            BemanExemplar_pkgName
+            JSON BemanExemplar_pkgName
             ERROR_VARIABLE BemanExemplar_error
             GET "${BemanExemplar_depObj}"
             "package_name"
@@ -118,8 +112,7 @@ function(BemanExemplar_provideDependency method package_name)
 
         # Get the "git_repository" field and store it in BemanExemplar_repo
         string(
-            JSON
-            BemanExemplar_repo
+            JSON BemanExemplar_repo
             ERROR_VARIABLE BemanExemplar_error
             GET "${BemanExemplar_depObj}"
             "git_repository"
@@ -133,8 +126,7 @@ function(BemanExemplar_provideDependency method package_name)
 
         # Get the "git_tag" field and store it in BemanExemplar_tag
         string(
-            JSON
-            BemanExemplar_tag
+            JSON BemanExemplar_tag
             ERROR_VARIABLE BemanExemplar_error
             GET "${BemanExemplar_depObj}"
             "git_tag"
@@ -149,14 +141,12 @@ function(BemanExemplar_provideDependency method package_name)
         if(method STREQUAL "FIND_PACKAGE")
             if(package_name STREQUAL BemanExemplar_pkgName)
                 string(
-                    APPEND
-                    BemanExemplar_debug
+                    APPEND BemanExemplar_debug
                     "Redirecting find_package calls for ${BemanExemplar_pkgName} "
                     "to FetchContent logic.\n"
                 )
                 string(
-                    APPEND
-                    BemanExemplar_debug
+                    APPEND BemanExemplar_debug
                     "Fetching ${BemanExemplar_repo} at "
                     "${BemanExemplar_tag} according to ${BemanExemplar_lockfile}."
                 )
@@ -175,8 +165,7 @@ function(BemanExemplar_provideDependency method package_name)
                 # `include(Catch)` works.
                 if(BemanExemplar_pkgName STREQUAL "Catch2")
                     list(
-                        APPEND
-                        CMAKE_MODULE_PATH
+                        APPEND CMAKE_MODULE_PATH
                         "${${BemanExemplar_name}_SOURCE_DIR}/extras"
                     )
                     set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)


### PR DESCRIPTION
This commit implements build telemetry support in exemplar by bringing in the new telemetry functionality added to exemplar by Steve Downey in https://github.com/bemanproject/infra/pull/23.

The only changes to CMake are adding the statements include(infra/cmake/BuildTelemetryConfig.cmake) and configure_build_telemetry() to the top-level CMakeLists.txt; the rest of the change just updates infra to the latest main via beman-submodule.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
