### PR TITLE
Restore a missing Clang 18 unit test

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -99,7 +99,17 @@ jobs:
                 }
               ]
             },
-            { "versions": ["18", "17"],
+            { "versions": ["18"],
+              "tests": [
+                { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
+                  "tests": [{"stdlibs": ["libc++"], "tests": ["Release.Default"]}]
+                },
+                { "cxxversions": ["c++23", "c++20", "c++17"],
+                  "tests": [{"stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
+                }
+              ]
+            },
+            { "versions": ["17"],
               "tests": [
                 { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
                   "tests": [{"stdlibs": ["libc++"], "tests": ["Release.Default"]}]

--- a/README.md
+++ b/README.md
@@ -147,8 +147,10 @@ You can disable building tests by setting CMake option `BEMAN_EXEMPLAR_BUILD_TES
 | GCC        | 15-13   | C++26-C++17   | libstdc++         |
 | GCC        | 12-11   | C++23-C++17   | libstdc++         |
 | Clang      | 22-19   | C++26-C++17   | libstdc++, libc++ |
-| Clang      | 18-17   | C++26-C++17   | libc++            |
-| Clang      | 18-17   | C++20, C++17  | libstdc++         |
+| Clang      | 18      | C++26-C++17   | libc++            |
+| Clang      | 18      | C++23-C++17   | libstdc++         |
+| Clang      | 17      | C++26-C++17   | libc++            |
+| Clang      | 17      | C++20, C++17  | libstdc++         |
 | AppleClang | latest  | C++26-C++17   | libc++            |
 | MSVC       | latest  | C++23         | MSVC STL          |
 

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
@@ -79,8 +79,7 @@ jobs:
                     { "stdlibs": ["libstdc++", "libc++"],
                       "tests": [
                         "Debug.Default", "Release.Default", "Release.TSan",
-                        "Release.MaxSan", "Debug.Werror"{% if cookiecutter.library_type == "static" %}, "Debug.Dynamic"{% endif %}
-
+                        "Release.MaxSan", "Debug.Werror"
                       ]
                     }
                   ]
@@ -101,7 +100,17 @@ jobs:
                 }
               ]
             },
-            { "versions": ["18", "17"],
+            { "versions": ["18"],
+              "tests": [
+                { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
+                  "tests": [{"stdlibs": ["libc++"], "tests": ["Release.Default"]}]
+                },
+                { "cxxversions": ["c++23", "c++20", "c++17"],
+                  "tests": [{"stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
+                }
+              ]
+            },
+            { "versions": ["17"],
               "tests": [
                 { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
                   "tests": [{"stdlibs": ["libc++"], "tests": ["Release.Default"]}]

--- a/cookiecutter/{{cookiecutter.project_name}}/README.md
+++ b/cookiecutter/{{cookiecutter.project_name}}/README.md
@@ -163,8 +163,10 @@ You can disable building tests by setting CMake option `BEMAN_{{cookiecutter.pro
 | GCC        | 15-13   | C++26-C++17   | libstdc++         |
 | GCC        | 12-11   | C++23-C++17   | libstdc++         |
 | Clang      | 22-19   | C++26-C++17   | libstdc++, libc++ |
-| Clang      | 18-17   | C++26-C++17   | libc++            |
-| Clang      | 18-17   | C++20, C++17  | libstdc++         |
+| Clang      | 18      | C++26-C++17   | libc++            |
+| Clang      | 18      | C++23-C++17   | libstdc++         |
+| Clang      | 17      | C++26-C++17   | libc++            |
+| Clang      | 17      | C++20, C++17  | libstdc++         |
 | AppleClang | latest  | C++26-C++17   | libc++            |
 | MSVC       | latest  | C++23         | MSVC STL          |
 


### PR DESCRIPTION
Commit 48638eeb25ccfe125b3db13deb1001326e012317 was intended to
address the unit test issues that occurred when our test images that
use older versions of Clang were upgraded to libstdc++ 15, introducing
incompatibilities. But among the unit tests it removed, Clang
18/C++23/libstdc++ was removed unnecessarily. This commit adjusts the
CI matrix to restore that job.
