### PR TITLE
Restore beman-tidy pre-commit check removed by pre-commit autoupdate

### DIFF
--- a/cookiecutter/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -39,4 +39,13 @@ repos:
     hooks:
       - id: codespell
 
+{% if not cookiecutter._generating_exemplar %}
+    # Beman Standard checking via beman-tidy
+  - repo: https://github.com/bemanproject/beman-tidy
+    rev: v0.3.1
+    hooks:
+    - id: beman-tidy
+
+{% endif %}
+
 exclude: 'cookiecutter/|infra/'


### PR DESCRIPTION
b1e7015b1bd62ce5b20009cec7ee98ba5c783818 unintentionally stripped the beman-tidy check from the cookiecutter repository. It seems to have trouble with the Jinja markup. Created
https://github.com/bemanproject/infra-workflows/issues/32 to track that issue. In the meantime, this commit reverts the removal.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
