### PR TITLE
Fix cookiecutter CI check

### DIFF
--- a/cookiecutter/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -47,5 +47,4 @@ repos:
     - id: beman-tidy
 
 {% endif %}
-
 exclude: 'cookiecutter/|infra/'


### PR DESCRIPTION
This was broken by a blank line unintentionally added by b0b9b981e534444703975e54b4b143b73a8f1bfe.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
