### PR TITLE
Update infra and move INSTALL_GTEST parameter into lockfile.json

### DIFF
--- a/cookiecutter/{{cookiecutter.project_name}}/infra/.beman_submodule
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/.beman_submodule
@@ -1,3 +1,3 @@
 [beman_submodule]
 remote=https://github.com/bemanproject/infra.git
-commit_hash=dfdb103b5fc9cccd3424c377130e318466f1dd89
+commit_hash=ea3ef79f77fdcc378149ebc7406e81e9ceb04146

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/use-fetch-content.cmake
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/use-fetch-content.cmake
@@ -157,7 +157,50 @@ function(BemanExemplar_provideDependency method package_name)
                     GIT_TAG "${BemanExemplar_tag}"
                     EXCLUDE_FROM_ALL
                 )
-                set(INSTALL_GTEST OFF) # Disable GoogleTest installation
+
+                # Apply per-dependency cmake_args from the lockfile
+                string(
+                    JSON BemanExemplar_cmakeArgs
+                    ERROR_VARIABLE BemanExemplar_cmakeArgsError
+                    GET "${BemanExemplar_depObj}"
+                    "cmake_args"
+                )
+                if(NOT BemanExemplar_cmakeArgsError)
+                    string(
+                        JSON BemanExemplar_numCmakeArgs
+                        LENGTH "${BemanExemplar_cmakeArgs}"
+                    )
+                    if(BemanExemplar_numCmakeArgs GREATER 0)
+                        math(
+                            EXPR
+                            BemanExemplar_maxArgIndex
+                            "${BemanExemplar_numCmakeArgs} - 1"
+                        )
+                        foreach(
+                            BemanExemplar_argIndex
+                            RANGE "${BemanExemplar_maxArgIndex}"
+                        )
+                            string(
+                                JSON BemanExemplar_argKey
+                                MEMBER "${BemanExemplar_cmakeArgs}"
+                                "${BemanExemplar_argIndex}"
+                            )
+                            string(
+                                JSON BemanExemplar_argValue
+                                GET "${BemanExemplar_cmakeArgs}"
+                                "${BemanExemplar_argKey}"
+                            )
+                            message(
+                                DEBUG
+                                "Setting ${BemanExemplar_argKey}=${BemanExemplar_argValue} for ${BemanExemplar_name}"
+                            )
+                            set("${BemanExemplar_argKey}"
+                                "${BemanExemplar_argValue}"
+                            )
+                        endforeach()
+                    endif()
+                endif()
+
                 FetchContent_MakeAvailable("${BemanExemplar_name}")
 
                 # Catch2's CTest integration module isn't on CMAKE_MODULE_PATH

--- a/cookiecutter/{{cookiecutter.project_name}}/lockfile.json
+++ b/cookiecutter/{{cookiecutter.project_name}}/lockfile.json
@@ -5,7 +5,10 @@
       "name": "googletest",
       "package_name": "GTest",
       "git_repository": "https://github.com/google/googletest.git",
-      "git_tag": "6910c9d9165801d8827d628cb72eb7ea9dd538c5"
+      "git_tag": "6910c9d9165801d8827d628cb72eb7ea9dd538c5",
+      "cmake_args": {
+        "INSTALL_GTEST": "OFF"
+      }
     }
 {% elif cookiecutter.unit_test_library == "catch2" %}
     {

--- a/infra/.beman_submodule
+++ b/infra/.beman_submodule
@@ -1,3 +1,3 @@
 [beman_submodule]
 remote=https://github.com/bemanproject/infra.git
-commit_hash=dfdb103b5fc9cccd3424c377130e318466f1dd89
+commit_hash=ea3ef79f77fdcc378149ebc7406e81e9ceb04146

--- a/infra/cmake/use-fetch-content.cmake
+++ b/infra/cmake/use-fetch-content.cmake
@@ -157,7 +157,50 @@ function(BemanExemplar_provideDependency method package_name)
                     GIT_TAG "${BemanExemplar_tag}"
                     EXCLUDE_FROM_ALL
                 )
-                set(INSTALL_GTEST OFF) # Disable GoogleTest installation
+
+                # Apply per-dependency cmake_args from the lockfile
+                string(
+                    JSON BemanExemplar_cmakeArgs
+                    ERROR_VARIABLE BemanExemplar_cmakeArgsError
+                    GET "${BemanExemplar_depObj}"
+                    "cmake_args"
+                )
+                if(NOT BemanExemplar_cmakeArgsError)
+                    string(
+                        JSON BemanExemplar_numCmakeArgs
+                        LENGTH "${BemanExemplar_cmakeArgs}"
+                    )
+                    if(BemanExemplar_numCmakeArgs GREATER 0)
+                        math(
+                            EXPR
+                            BemanExemplar_maxArgIndex
+                            "${BemanExemplar_numCmakeArgs} - 1"
+                        )
+                        foreach(
+                            BemanExemplar_argIndex
+                            RANGE "${BemanExemplar_maxArgIndex}"
+                        )
+                            string(
+                                JSON BemanExemplar_argKey
+                                MEMBER "${BemanExemplar_cmakeArgs}"
+                                "${BemanExemplar_argIndex}"
+                            )
+                            string(
+                                JSON BemanExemplar_argValue
+                                GET "${BemanExemplar_cmakeArgs}"
+                                "${BemanExemplar_argKey}"
+                            )
+                            message(
+                                DEBUG
+                                "Setting ${BemanExemplar_argKey}=${BemanExemplar_argValue} for ${BemanExemplar_name}"
+                            )
+                            set("${BemanExemplar_argKey}"
+                                "${BemanExemplar_argValue}"
+                            )
+                        endforeach()
+                    endif()
+                endif()
+
                 FetchContent_MakeAvailable("${BemanExemplar_name}")
 
                 # Catch2's CTest integration module isn't on CMAKE_MODULE_PATH

--- a/lockfile.json
+++ b/lockfile.json
@@ -4,7 +4,10 @@
       "name": "googletest",
       "package_name": "GTest",
       "git_repository": "https://github.com/google/googletest.git",
-      "git_tag": "6910c9d9165801d8827d628cb72eb7ea9dd538c5"
+      "git_tag": "6910c9d9165801d8827d628cb72eb7ea9dd538c5",
+      "cmake_args": {
+        "INSTALL_GTEST": "OFF"
+      }
     }
   ]
 }


### PR DESCRIPTION
This prevents us from needing to add bespoke per-dependency logic directly into use-fetch-content.cmake

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
