### PR TITLE
ci: raise gtest_discover_tests DISCOVERY_TIMEOUT to 60s

### DIFF
--- a/cookiecutter/{{cookiecutter.project_name}}/tests/beman/{{cookiecutter.project_name}}/CMakeLists.txt
+++ b/cookiecutter/{{cookiecutter.project_name}}/tests/beman/{{cookiecutter.project_name}}/CMakeLists.txt
@@ -20,7 +20,7 @@ target_link_libraries(
 
 {% if cookiecutter.unit_test_library == "gtest" %}
 include(GoogleTest)
-gtest_discover_tests(beman.{{cookiecutter.project_name}}.tests.{{identity}})
+gtest_discover_tests(beman.{{cookiecutter.project_name}}.tests.{{identity}} DISCOVERY_TIMEOUT 60)
 {% elif cookiecutter.unit_test_library == "catch2" %}
 include(Catch)
 catch_discover_tests(beman.{{cookiecutter.project_name}}.tests.{{identity}})

--- a/tests/beman/exemplar/CMakeLists.txt
+++ b/tests/beman/exemplar/CMakeLists.txt
@@ -10,4 +10,4 @@ target_link_libraries(
 )
 
 include(GoogleTest)
-gtest_discover_tests(beman.exemplar.tests.identity)
+gtest_discover_tests(beman.exemplar.tests.identity DISCOVERY_TIMEOUT 60)


### PR DESCRIPTION
## Summary
- The default 5-second `DISCOVERY_TIMEOUT` for `gtest_discover_tests` intermittently fires on the MSVC Debug runner — discovery just runs the test binary with `--gtest_list_tests`, but Debug-mode MSVC builds can take longer than 5s to launch. Example failure: https://github.com/bemanproject/transform_view/actions/runs/25011381871/job/73247753008
- Pass `DISCOVERY_TIMEOUT 60` in both the exemplar tests and the cookiecutter template so generated projects inherit the fix.

## Test plan
- [ ] CI passes on this PR (Linux/macOS/Windows matrix)
- [ ] Cookiecutter check still generates a buildable project

🤖 Generated with [Claude Code](https://claude.com/claude-code)