### PR TITLE
Add vcpkg port templates, manifest, and CI/release workflows

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -13,10 +13,10 @@ on:
 
 jobs:
   beman-submodule-check:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@1.5.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@1.6.0
 
   preset-test:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-preset-test.yml@1.5.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-preset-test.yml@1.6.0
     with:
       matrix_config: >
         [
@@ -31,7 +31,7 @@ jobs:
         ]
 
   build-and-test:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-build-and-test.yml@1.5.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-build-and-test.yml@1.6.0
     with:
       matrix_config: >
         {
@@ -144,7 +144,12 @@ jobs:
           ]
         }
 
+  vcpkg-ci:
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-vcpkg-ci.yml@1.6.0
+    with:
+      port_name: beman-exemplar
+
   create-issue-when-fault:
     needs: [preset-test, build-and-test]
     if: failure() && github.event_name == 'schedule'
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.5.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.6.0

--- a/.github/workflows/pre-commit-check.yml
+++ b/.github/workflows/pre-commit-check.yml
@@ -16,4 +16,4 @@ permissions:
 
 jobs:
   pre-commit:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-pre-commit.yml@1.5.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-pre-commit.yml@1.6.0

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   auto-update-pre-commit:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-update-pre-commit.yml@1.5.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-update-pre-commit.yml@1.6.0
     secrets:
       APP_ID: ${{ secrets.AUTO_PR_BOT_APP_ID }}
       PRIVATE_KEY: ${{ secrets.AUTO_PR_BOT_PRIVATE_KEY }}

--- a/.github/workflows/vcpkg-release.yml
+++ b/.github/workflows/vcpkg-release.yml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: vcpkg registry release
+on:
+  release:
+    types: [published]
+jobs:
+  vcpkg-release:
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-vcpkg-release.yml@1.6.0
+    with:
+      port_name: beman-exemplar
+    secrets:
+      VCPKG_REGISTRY_TOKEN: ${{ secrets.VCPKG_REGISTRY_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,4 +39,4 @@ repos:
     hooks:
       - id: codespell
 
-exclude: 'cookiecutter/|infra/'
+exclude: 'cookiecutter/|infra/|port/'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(
     # targets (e.g., library, executable, etc.).
     DESCRIPTION "A Beman Library Exemplar"
     LANGUAGES CXX
-    VERSION 0.1.0
+    VERSION 2.3.0
 )
 
 # [CMAKE.SKIP_TESTS]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,30 @@ ctest --test-dir build
 
 ## Dependency Management
 
+### vcpkg
+
+The best way to install the project's dependencies is to use the vcpkg workflow.
+
+To do so, make sure vcpkg is installed and `VCPKG_ROOT` is defined in your environment,
+then specify
+`-DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"`. Vcpkg will handle
+the project's dependencies, including GoogleTest.
+
+Example commands:
+
+```
+cmake \
+  -B build \
+  -S . \
+  -DCMAKE_CXX_STANDARD=17 \
+  -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+cmake --build build
+ctest --test-dir build
+```
+
+The file `./vcpkg.json` configures the list of dependencies that will be configured by
+vcpkg.
+
 ### FetchContent
 
 Instead of installing the project's dependencies via a package manager, you can optionally

--- a/README.md
+++ b/README.md
@@ -179,6 +179,17 @@ For details on building beman.exemplar without using a CMake preset, refer to th
 
 ### Installation
 
+#### Vcpkg
+
+The preferred way to install exemplar is via vcpkg. To do so, after installing vcpkg
+itself, you need to add support for the Beman project's [vcpkg
+registry](https://github.com/bemanproject/vcpkg-registry) by configuring a
+`vcpkg-configuration.json` file (which exemplar [provides](vcpkg-configuration.json)).
+
+Then, simply run `vcpkg install beman-exemplar`.
+
+#### Manual
+
 To install beman.exemplar globally after building with the `gcc-release` preset, you can
 run:
 

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
@@ -13,10 +13,10 @@ on:
 
 jobs:
   beman-submodule-check:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@1.5.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@1.6.0
 
   preset-test:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-preset-test.yml@1.5.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-preset-test.yml@1.6.0
     with:
       matrix_config: >
         [
@@ -31,7 +31,7 @@ jobs:
         ]
 
   build-and-test:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-build-and-test.yml@1.5.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-build-and-test.yml@1.6.0
     with:
       matrix_config: >
         {
@@ -145,7 +145,12 @@ jobs:
           ]
         }
 
+  vcpkg-ci:
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-vcpkg-ci.yml@1.6.0
+    with:
+      port_name: beman-{{cookiecutter.project_name.replace('_', '-')}}
+
   create-issue-when-fault:
     needs: [preset-test, build-and-test]
     if: failure() && github.event_name == 'schedule'
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.5.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.6.0

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit-check.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit-check.yml
@@ -16,4 +16,4 @@ permissions:
 
 jobs:
   pre-commit:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-pre-commit.yml@1.5.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-pre-commit.yml@1.6.0

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit-update.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit-update.yml
@@ -10,7 +10,7 @@ on:
 {% raw -%}
 jobs:
   auto-update-pre-commit:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-update-pre-commit.yml@1.5.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-update-pre-commit.yml@1.6.0
     secrets:
       APP_ID: ${{ secrets.AUTO_PR_BOT_APP_ID }}
       PRIVATE_KEY: ${{ secrets.AUTO_PR_BOT_PRIVATE_KEY }}

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/vcpkg-release.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/vcpkg-release.yml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: vcpkg registry release
+on:
+  release:
+    types: [published]
+jobs:
+  vcpkg-release:
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-vcpkg-release.yml@1.6.0
+    with:
+      port_name: beman-{{cookiecutter.project_name.replace('_', '-')}}
+{%- raw %}
+    secrets:
+      VCPKG_REGISTRY_TOKEN: ${{ secrets.VCPKG_REGISTRY_TOKEN }}
+{%- endraw %}
+

--- a/cookiecutter/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -47,4 +47,4 @@ repos:
     - id: beman-tidy
 
 {% endif %}
-exclude: 'cookiecutter/|infra/'
+exclude: 'cookiecutter/|infra/|port/'

--- a/cookiecutter/{{cookiecutter.project_name}}/CMakeLists.txt
+++ b/cookiecutter/{{cookiecutter.project_name}}/CMakeLists.txt
@@ -7,7 +7,11 @@ project(
     # targets (e.g., library, executable, etc.).
     DESCRIPTION "{{cookiecutter.description}}"
     LANGUAGES CXX
+{% if cookiecutter._generating_exemplar %}
+    VERSION 2.3.0
+{% else %}
     VERSION 0.1.0
+{% endif %}
 )
 
 # [CMAKE.SKIP_TESTS]

--- a/cookiecutter/{{cookiecutter.project_name}}/CONTRIBUTING.md
+++ b/cookiecutter/{{cookiecutter.project_name}}/CONTRIBUTING.md
@@ -54,6 +54,30 @@ ctest --test-dir build
 
 ## Dependency Management
 
+### vcpkg
+
+The best way to install the project's dependencies is to use the vcpkg workflow.
+
+To do so, make sure vcpkg is installed and `VCPKG_ROOT` is defined in your environment,
+then specify
+`-DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"`. Vcpkg will handle
+the project's dependencies, including GoogleTest.
+
+Example commands:
+
+```
+cmake \
+  -B build \
+  -S . \
+  -DCMAKE_CXX_STANDARD=17 \
+  -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+cmake --build build
+ctest --test-dir build
+```
+
+The file `./vcpkg.json` configures the list of dependencies that will be configured by
+vcpkg.
+
 ### FetchContent
 
 Instead of installing the project's dependencies via a package manager, you can optionally

--- a/cookiecutter/{{cookiecutter.project_name}}/README.md
+++ b/cookiecutter/{{cookiecutter.project_name}}/README.md
@@ -195,6 +195,17 @@ For details on building beman.{{cookiecutter.project_name}} without using a CMak
 
 ### Installation
 
+#### Vcpkg
+
+The preferred way to install {{cookiecutter.project_name}} is via vcpkg. To do so, after installing vcpkg
+itself, you need to add support for the Beman project's [vcpkg
+registry](https://github.com/bemanproject/vcpkg-registry) by configuring a
+`vcpkg-configuration.json` file (which {{cookiecutter.project_name}} [provides](vcpkg-configuration.json)).
+
+Then, simply run `vcpkg install beman-{{cookiecutter.project_name.replace("_", "-")}}`.
+
+#### Manual
+
 To install beman.{{cookiecutter.project_name}} globally after building with the `gcc-release` preset, you can
 run:
 

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/.beman_submodule
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/.beman_submodule
@@ -1,3 +1,3 @@
 [beman_submodule]
 remote=https://github.com/bemanproject/infra.git
-commit_hash=ea3ef79f77fdcc378149ebc7406e81e9ceb04146
+commit_hash=3a49dffbffbfd1c405ce36091dfc68ad02dd6965

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/use-fetch-content.cmake
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/use-fetch-content.cmake
@@ -222,6 +222,8 @@ function(BemanExemplar_provideDependency method package_name)
     endforeach()
 endfunction()
 
+set(BEMAN_USE_FETCH_CONTENT_ENABLED ON)
+
 cmake_language(
     SET_DEPENDENCY_PROVIDER BemanExemplar_provideDependency
     SUPPORTED_METHODS FIND_PACKAGE

--- a/cookiecutter/{{cookiecutter.project_name}}/port/portfile.cmake.in
+++ b/cookiecutter/{{cookiecutter.project_name}}/port/portfile.cmake.in
@@ -1,0 +1,28 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO bemanproject/{{cookiecutter.project_name}}
+    REF "v@VERSION@"
+    SHA512 @SHA512@
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBEMAN_EXEMPLAR_BUILD_TESTS=OFF
+        -DBEMAN_EXEMPLAR_BUILD_EXAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME beman.{{cookiecutter.project_name}}
+    CONFIG_PATH lib/cmake/beman.{{cookiecutter.project_name}}
+)
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug"
+    "${CURRENT_PACKAGES_DIR}/lib"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/cookiecutter/{{cookiecutter.project_name}}/port/vcpkg.json.in
+++ b/cookiecutter/{{cookiecutter.project_name}}/port/vcpkg.json.in
@@ -1,0 +1,17 @@
+{
+  "name": "beman-{{cookiecutter.project_name.replace('_', '-')}}",
+  "version-semver": "@VERSION@",
+  "description": "{{cookiecutter.description}}",
+  "homepage": "https://github.com/bemanproject/{{cookiecutter.project_name}}",
+  "license": "Apache-2.0 WITH LLVM-exception",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/cookiecutter/{{cookiecutter.project_name}}/vcpkg-configuration.json
+++ b/cookiecutter/{{cookiecutter.project_name}}/vcpkg-configuration.json
@@ -1,0 +1,15 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "repository": "https://github.com/microsoft/vcpkg.git",
+    "baseline": "dc8d75cfc3281b8e2a4ed8ee4163c891190df932"
+  },
+  "registries": [
+    {
+      "kind": "git",
+      "repository": "https://github.com/bemanproject/vcpkg-registry.git",
+      "baseline": "efa65af59b2548a25655338a99118fc8bfaac304",
+      "packages": ["beman-*"]
+    }
+  ]
+}

--- a/cookiecutter/{{cookiecutter.project_name}}/vcpkg.json
+++ b/cookiecutter/{{cookiecutter.project_name}}/vcpkg.json
@@ -1,0 +1,23 @@
+{
+  "name": "beman-{{cookiecutter.project_name.replace('_', '-')}}",
+{% if cookiecutter._generating_exemplar %}
+  "version-semver": "2.3.0",
+{% else %}
+  "version-semver": "0.1.0",
+{% endif %}
+{% if cookiecutter.unit_test_library == "gtest" %}
+  "dependencies": [
+    {
+      "name": "gtest",
+      "host": true
+    }
+  ]
+{% elif cookiecutter.unit_test_library == "catch2" %}
+  "dependencies": [
+    {
+      "name": "catch2",
+      "host": true
+    }
+  ]
+{% endif %}
+}

--- a/infra/.beman_submodule
+++ b/infra/.beman_submodule
@@ -1,3 +1,3 @@
 [beman_submodule]
 remote=https://github.com/bemanproject/infra.git
-commit_hash=ea3ef79f77fdcc378149ebc7406e81e9ceb04146
+commit_hash=3a49dffbffbfd1c405ce36091dfc68ad02dd6965

--- a/infra/cmake/use-fetch-content.cmake
+++ b/infra/cmake/use-fetch-content.cmake
@@ -222,6 +222,8 @@ function(BemanExemplar_provideDependency method package_name)
     endforeach()
 endfunction()
 
+set(BEMAN_USE_FETCH_CONTENT_ENABLED ON)
+
 cmake_language(
     SET_DEPENDENCY_PROVIDER BemanExemplar_provideDependency
     SUPPORTED_METHODS FIND_PACKAGE

--- a/port/portfile.cmake.in
+++ b/port/portfile.cmake.in
@@ -1,0 +1,28 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO bemanproject/exemplar
+    REF "v@VERSION@"
+    SHA512 @SHA512@
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBEMAN_EXEMPLAR_BUILD_TESTS=OFF
+        -DBEMAN_EXEMPLAR_BUILD_EXAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME beman.exemplar
+    CONFIG_PATH lib/cmake/beman.exemplar
+)
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug"
+    "${CURRENT_PACKAGES_DIR}/lib"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/port/vcpkg.json.in
+++ b/port/vcpkg.json.in
@@ -1,0 +1,17 @@
+{
+  "name": "beman-exemplar",
+  "version-semver": "@VERSION@",
+  "description": "A Beman Library Exemplar",
+  "homepage": "https://github.com/bemanproject/exemplar",
+  "license": "Apache-2.0 WITH LLVM-exception",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,15 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "repository": "https://github.com/microsoft/vcpkg.git",
+    "baseline": "dc8d75cfc3281b8e2a4ed8ee4163c891190df932"
+  },
+  "registries": [
+    {
+      "kind": "git",
+      "repository": "https://github.com/bemanproject/vcpkg-registry.git",
+      "baseline": "efa65af59b2548a25655338a99118fc8bfaac304",
+      "packages": ["beman-*"]
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "beman-exemplar",
+  "version-semver": "2.3.0",
+  "dependencies": [
+    {
+      "name": "gtest",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
- Add port/vcpkg.json.in and port/portfile.cmake.in templates
- Add vcpkg.json manifest for developer builds with gtest
- Add vcpkg-configuration.json for registry resolution
- Add vcpkg CI job to ci_tests.yml
- Add vcpkg-release.yml workflow for registry updates on release
- Add updated wording to README.md and CONTRIBUTING.md
- Update infra/ to pick up BEMAN_USE_FETCH_CONTENT_ENABLED flag
- Update workflows from 1.5.3 to 1.6.0

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
