### PR TITLE
Bump vcpkg registry baselines

### DIFF
--- a/cookiecutter/{{cookiecutter.project_name}}/vcpkg-configuration.json
+++ b/cookiecutter/{{cookiecutter.project_name}}/vcpkg-configuration.json
@@ -2,13 +2,13 @@
   "default-registry": {
     "kind": "git",
     "repository": "https://github.com/microsoft/vcpkg.git",
-    "baseline": "dc8d75cfc3281b8e2a4ed8ee4163c891190df932"
+    "baseline": "80f9bcfa455e875d9c1bf7a7c6692d7e1e481061"
   },
   "registries": [
     {
       "kind": "git",
       "repository": "https://github.com/bemanproject/vcpkg-registry.git",
-      "baseline": "efa65af59b2548a25655338a99118fc8bfaac304",
+      "baseline": "5195f94f2b550163917c1152180fc59bbd760556",
       "packages": ["beman-*"]
     }
   ]

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,13 +2,13 @@
   "default-registry": {
     "kind": "git",
     "repository": "https://github.com/microsoft/vcpkg.git",
-    "baseline": "dc8d75cfc3281b8e2a4ed8ee4163c891190df932"
+    "baseline": "80f9bcfa455e875d9c1bf7a7c6692d7e1e481061"
   },
   "registries": [
     {
       "kind": "git",
       "repository": "https://github.com/bemanproject/vcpkg-registry.git",
-      "baseline": "efa65af59b2548a25655338a99118fc8bfaac304",
+      "baseline": "5195f94f2b550163917c1152180fc59bbd760556",
       "packages": ["beman-*"]
     }
   ]


### PR DESCRIPTION
This allows users to pick up the newly released version 2.3.0 of exemplar.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
