### PR TITLE
Add beman-tidy config to exemplar

### DIFF
--- a/.beman-tidy.yaml
+++ b/.beman-tidy.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This is the config file for beman-tidy, which checks compliance with the Beman Standard (https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md)
+# Check documentation for beman-tidy here:
+# https://github.com/bemanproject/beman-tidy/blob/main/README.md
+
+disabled_rules:
+  - readme.title
+ignored_paths:
+    # None

--- a/cookiecutter/{{cookiecutter.project_name}}/.beman-tidy.yaml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.beman-tidy.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This is the config file for beman-tidy, which checks compliance with the Beman Standard (https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md)
+# Check documentation for beman-tidy here:
+# https://github.com/bemanproject/beman-tidy/blob/main/README.md
+
+{% if cookiecutter._generating_exemplar %}
+disabled_rules:
+  - readme.title
+{% else %}
+disabled_rules:
+    # None
+{% endif %}
+ignored_paths:
+    # None


### PR DESCRIPTION
This PR is in anticipation of [this PR on beman-tidy](https://github.com/bemanproject/beman-tidy/pull/279) which introduces the possibility of disable entire rules. And in anticipation of undoing [this temporary CI pause](https://github.com/bemanproject/beman-tidy/pull/276).

This does two things
- adds `.beman-tidy.yaml` with pre-ignored rules to fix CI on beman-tidy 
- adds `cookiecutter/{{cookiecutter.project_name}}/.beman-tidy.yaml` to the template in order to prep new repos with a `.beman-tidy.yaml` config file and how to use it