### PR TITLE
Fix untemplated 'EXEMPLAR' in cookiecutter for portfile

### DIFF
--- a/cookiecutter/{{cookiecutter.project_name}}/port/portfile.cmake.in
+++ b/cookiecutter/{{cookiecutter.project_name}}/port/portfile.cmake.in
@@ -9,8 +9,8 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DBEMAN_EXEMPLAR_BUILD_TESTS=OFF
-        -DBEMAN_EXEMPLAR_BUILD_EXAMPLES=OFF
+        -DBEMAN_{{cookiecutter.project_name.upper()}}_BUILD_TESTS=OFF
+        -DBEMAN_{{cookiecutter.project_name.upper()}}_BUILD_EXAMPLES=OFF
 )
 
 vcpkg_cmake_install()


### PR DESCRIPTION
<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
