### PR TITLE
Add missing SPDX license identifiers to enforce file.license_id from the beman standard

### DIFF
--- a/.github/workflows/pre-commit-check.yml
+++ b/.github/workflows/pre-commit-check.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 name: Lint Check (pre-commit)
 
 on:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # MD033/no-inline-html : Inline HTML : https://github.com/DavidAnson/markdownlint/blob/v0.35.0/doc/md033.md
 # Disable inline html linter is needed for <details> <summary>
 MD033: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
 # Development
 
 ## Configure and Build the Project Using CMake Presets

--- a/cookiecutter/check_cookiecutter.sh
+++ b/cookiecutter/check_cookiecutter.sh
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #!/usr/bin/env bash
 
 set -euo pipefail

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit-check.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit-check.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 name: Lint Check (pre-commit)
 
 on:

--- a/cookiecutter/{{cookiecutter.project_name}}/.markdownlint.yaml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.markdownlint.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # MD033/no-inline-html : Inline HTML : https://github.com/DavidAnson/markdownlint/blob/v0.35.0/doc/md033.md
 # Disable inline html linter is needed for <details> <summary>
 MD033: false

--- a/cookiecutter/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:

--- a/cookiecutter/{{cookiecutter.project_name}}/CONTRIBUTING.md
+++ b/cookiecutter/{{cookiecutter.project_name}}/CONTRIBUTING.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
 # Development
 
 ## Configure and Build the Project Using CMake Presets

--- a/cookiecutter/{{cookiecutter.project_name}}/examples/identity_direct_usage.cpp
+++ b/cookiecutter/{{cookiecutter.project_name}}/examples/identity_direct_usage.cpp
@@ -1,5 +1,5 @@
-{% set identity = "identity" if cookiecutter._generating_exemplar else "todo" %}
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+{% set identity = "identity" if cookiecutter._generating_exemplar else "todo" %}
 
 #include <beman/{{cookiecutter.project_name}}/{{identity}}.hpp>
 

--- a/cookiecutter/{{cookiecutter.project_name}}/include/beman/{{cookiecutter.project_name}}/CMakeLists.txt
+++ b/cookiecutter/{{cookiecutter.project_name}}/include/beman/{{cookiecutter.project_name}}/CMakeLists.txt
@@ -1,5 +1,5 @@
-{% set identity = "identity" if cookiecutter._generating_exemplar else "todo" %}
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+{% set identity = "identity" if cookiecutter._generating_exemplar else "todo" %}
 
 target_sources(
     beman.{{cookiecutter.project_name}}

--- a/cookiecutter/{{cookiecutter.project_name}}/include/beman/{{cookiecutter.project_name}}/identity.hpp
+++ b/cookiecutter/{{cookiecutter.project_name}}/include/beman/{{cookiecutter.project_name}}/identity.hpp
@@ -1,5 +1,5 @@
-{% set identity = "identity" if cookiecutter._generating_exemplar else "todo" %}
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+{% set identity = "identity" if cookiecutter._generating_exemplar else "todo" %}
 
 #ifndef BEMAN_{{cookiecutter.project_name.upper()}}_{{identity.upper()}}_HPP
 #define BEMAN_{{cookiecutter.project_name.upper()}}_{{identity.upper()}}_HPP

--- a/cookiecutter/{{cookiecutter.project_name}}/include/beman/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}.hpp
+++ b/cookiecutter/{{cookiecutter.project_name}}/include/beman/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}.hpp
@@ -1,5 +1,5 @@
-{% set identity = "identity" if cookiecutter._generating_exemplar else "todo" %}
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+{% set identity = "identity" if cookiecutter._generating_exemplar else "todo" %}
 
 #ifndef BEMAN_{{cookiecutter.project_name.upper()}}_{{cookiecutter.project_name.upper()}}_HPP
 #define BEMAN_{{cookiecutter.project_name.upper()}}_{{cookiecutter.project_name.upper()}}_HPP

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/.beman_submodule
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/.beman_submodule
@@ -1,3 +1,3 @@
 [beman_submodule]
 remote=https://github.com/bemanproject/infra.git
-commit_hash=1b14bad2cd2cf0e44d1aeb608557e0e35ce27eaa
+commit_hash=9bd493ce12ba5b7b01bc777f35d1e08a16889a90

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/.github/workflows/pre-commit.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/.github/workflows/pre-commit.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 name: Lint Check (pre-commit)
 
 on:

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/.pre-commit-config.yaml
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/BuildTelemetry.cmake
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/BuildTelemetry.cmake
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 include_guard(GLOBAL)
 
 include(${CMAKE_CURRENT_LIST_DIR}/BuildTelemetryConfig.cmake)

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/BuildTelemetryConfig.cmake
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/BuildTelemetryConfig.cmake
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 include_guard(GLOBAL)
 
 set(BUILD_TELEMETRY_DIR ${CMAKE_CURRENT_LIST_DIR})

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/Config.cmake.in
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/Config.cmake.in
@@ -1,5 +1,5 @@
-# cmake/Config.cmake.in -*-makefile-*-
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# cmake/Config.cmake.in -*-makefile-*-
 
 include(CMakeFindDependencyMacro)
 

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/telemetry.sh
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/telemetry.sh
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #!/usr/bin/env bash
 
 set -o nounset

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/use-fetch-content.cmake
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/use-fetch-content.cmake
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 cmake_minimum_required(VERSION 3.24)
 
 include(FetchContent)

--- a/cookiecutter/{{cookiecutter.project_name}}/port/portfile.cmake.in
+++ b/cookiecutter/{{cookiecutter.project_name}}/port/portfile.cmake.in
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO bemanproject/{{cookiecutter.project_name}}

--- a/cookiecutter/{{cookiecutter.project_name}}/src/beman/{{cookiecutter.project_name}}/CMakeLists.txt
+++ b/cookiecutter/{{cookiecutter.project_name}}/src/beman/{{cookiecutter.project_name}}/CMakeLists.txt
@@ -1,5 +1,5 @@
-{% set identity = "identity" if cookiecutter._generating_exemplar else "todo" %}
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+{% set identity = "identity" if cookiecutter._generating_exemplar else "todo" %}
 
 target_sources(
     beman.{{cookiecutter.project_name}}

--- a/cookiecutter/{{cookiecutter.project_name}}/src/beman/{{cookiecutter.project_name}}/identity.cpp
+++ b/cookiecutter/{{cookiecutter.project_name}}/src/beman/{{cookiecutter.project_name}}/identity.cpp
@@ -1,5 +1,5 @@
-{% set identity = "identity" if cookiecutter._generating_exemplar else "todo" %}
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+{% set identity = "identity" if cookiecutter._generating_exemplar else "todo" %}
 
 #include <beman/{{cookiecutter.project_name}}/{{identity}}.hpp>
 

--- a/cookiecutter/{{cookiecutter.project_name}}/tests/beman/{{cookiecutter.project_name}}/CMakeLists.txt
+++ b/cookiecutter/{{cookiecutter.project_name}}/tests/beman/{{cookiecutter.project_name}}/CMakeLists.txt
@@ -1,5 +1,5 @@
-{% set identity = "identity" if cookiecutter._generating_exemplar else "todo" %}
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+{% set identity = "identity" if cookiecutter._generating_exemplar else "todo" %}
 
 {% if cookiecutter.unit_test_library == "gtest" %}
 find_package(GTest REQUIRED)

--- a/cookiecutter/{{cookiecutter.project_name}}/tests/beman/{{cookiecutter.project_name}}/identity.test.cpp
+++ b/cookiecutter/{{cookiecutter.project_name}}/tests/beman/{{cookiecutter.project_name}}/identity.test.cpp
@@ -1,5 +1,5 @@
-{% set identity = "identity" if cookiecutter._generating_exemplar else "todo" %}
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+{% set identity = "identity" if cookiecutter._generating_exemplar else "todo" %}
 
 #include <beman/{{cookiecutter.project_name}}/{{identity}}.hpp>
 

--- a/infra/.beman_submodule
+++ b/infra/.beman_submodule
@@ -1,3 +1,3 @@
 [beman_submodule]
 remote=https://github.com/bemanproject/infra.git
-commit_hash=1b14bad2cd2cf0e44d1aeb608557e0e35ce27eaa
+commit_hash=9bd493ce12ba5b7b01bc777f35d1e08a16889a90

--- a/infra/.github/workflows/pre-commit.yml
+++ b/infra/.github/workflows/pre-commit.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 name: Lint Check (pre-commit)
 
 on:

--- a/infra/.pre-commit-config.yaml
+++ b/infra/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/infra/cmake/BuildTelemetry.cmake
+++ b/infra/cmake/BuildTelemetry.cmake
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 include_guard(GLOBAL)
 
 include(${CMAKE_CURRENT_LIST_DIR}/BuildTelemetryConfig.cmake)

--- a/infra/cmake/BuildTelemetryConfig.cmake
+++ b/infra/cmake/BuildTelemetryConfig.cmake
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 include_guard(GLOBAL)
 
 set(BUILD_TELEMETRY_DIR ${CMAKE_CURRENT_LIST_DIR})

--- a/infra/cmake/Config.cmake.in
+++ b/infra/cmake/Config.cmake.in
@@ -1,5 +1,5 @@
-# cmake/Config.cmake.in -*-makefile-*-
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# cmake/Config.cmake.in -*-makefile-*-
 
 include(CMakeFindDependencyMacro)
 

--- a/infra/cmake/telemetry.sh
+++ b/infra/cmake/telemetry.sh
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #!/usr/bin/env bash
 
 set -o nounset

--- a/infra/cmake/use-fetch-content.cmake
+++ b/infra/cmake/use-fetch-content.cmake
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 cmake_minimum_required(VERSION 3.24)
 
 include(FetchContent)

--- a/port/portfile.cmake.in
+++ b/port/portfile.cmake.in
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO bemanproject/exemplar

--- a/stamp.sh
+++ b/stamp.sh
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #!/usr/bin/env bash
 
 {


### PR DESCRIPTION
Fixes #374