### PR TITLE
Implement modules support

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -44,17 +44,42 @@ jobs:
                       "tests": [
                         "Debug.Default", "Release.Default", "Release.TSan",
                         "Release.MaxSan", "Debug.Werror",
-                        "Debug.Coverage"
+                        "Debug.Coverage", "Debug.-DBEMAN_EXEMPLAR_USE_MODULES=On"
                       ]
                     }
                   ]
                 },
-                { "cxxversions": ["c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++23"],
+                  "tests": [
+                    { "stdlibs": ["libstdc++"],
+                      "tests": [
+                        "Release.Default", "Debug.-DBEMAN_EXEMPLAR_USE_MODULES=On"
+                      ]
+                    }
+                  ]
+                },
+                { "cxxversions": ["c++20", "c++17"],
                   "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
                 }
               ]
             },
-            { "versions": ["15", "14", "13"],
+            { "versions": ["15"],
+              "tests": [
+                { "cxxversions": ["c++26", "c++23"],
+                  "tests": [
+                    { "stdlibs": ["libstdc++"],
+                      "tests": [
+                        "Release.Default", "Debug.-DBEMAN_EXEMPLAR_USE_MODULES=On"
+                      ]
+                    }
+                  ]
+                },
+                { "cxxversions": ["c++20", "c++17"],
+                  "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
+                }
+              ]
+            },
+            { "versions": ["14", "13"],
               "tests": [
                 { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
                   "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
@@ -78,12 +103,22 @@ jobs:
                     { "stdlibs": ["libstdc++", "libc++"],
                       "tests": [
                         "Debug.Default", "Release.Default", "Release.TSan",
-                        "Release.MaxSan", "Debug.Werror"
+                        "Release.MaxSan", "Debug.Werror",
+                        "Debug.-DBEMAN_EXEMPLAR_USE_MODULES=On"
                       ]
                     }
                   ]
                 },
-                { "cxxversions": ["c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++23"],
+                  "tests": [
+                    { "stdlibs": ["libstdc++", "libc++"],
+                      "tests": [
+                        "Release.Default", "Debug.-DBEMAN_EXEMPLAR_USE_MODULES=On"
+                      ]
+                    }
+                  ]
+                },
+                { "cxxversions": ["c++20", "c++17"],
                   "tests": [
                     {"stdlibs": ["libstdc++", "libc++"], "tests": ["Release.Default"]}
                   ]
@@ -135,7 +170,10 @@ jobs:
                 { "cxxversions": ["c++23"],
                   "tests": [
                     { "stdlibs": ["stl"],
-                      "tests": ["Debug.Default", "Release.Default", "Release.MaxSan"]
+                      "tests": [
+                        "Debug.Default", "Release.Default", "Release.MaxSan",
+                        "Debug.-DBEMAN_EXEMPLAR_USE_MODULES=On"
+                      ]
                     }
                   ]
                 }
@@ -148,6 +186,11 @@ jobs:
     uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-vcpkg-ci.yml@1.7.1
     with:
       port_name: beman-exemplar
+      feature_combinations: |
+        [
+          {"features": {}},
+          {"features": {"modules": true}}
+        ]
 
   create-issue-when-fault:
     needs: [preset-test, build-and-test]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 cmake_minimum_required(VERSION 3.30...4.3)
 
+include(infra/cmake/enable-experimental-import-std.cmake)
+
 project(
     beman.exemplar
     DESCRIPTION "A Beman Library Exemplar"
@@ -23,22 +25,55 @@ option(
     ${PROJECT_IS_TOP_LEVEL}
 )
 
+option(BEMAN_EXEMPLAR_USE_MODULES "Provide beman.exemplar as a C++ module" OFF)
+
+if(BEMAN_EXEMPLAR_USE_MODULES)
+    set(CMAKE_CXX_SCAN_FOR_MODULES ON)
+endif()
+
+configure_file(
+    "${PROJECT_SOURCE_DIR}/include/beman/exemplar/config_generated.hpp.in"
+    "${PROJECT_BINARY_DIR}/include/beman/exemplar/config_generated.hpp"
+    @ONLY
+)
+
 # for find of beman_install_library and configure_build_telemetry
 include(infra/cmake/beman-install-library.cmake)
 include(infra/cmake/BuildTelemetryConfig.cmake)
 
-add_library(beman.exemplar INTERFACE)
+if(BEMAN_EXEMPLAR_USE_MODULES)
+    add_library(beman.exemplar STATIC)
+else()
+    add_library(beman.exemplar INTERFACE)
+endif()
 add_library(beman::exemplar ALIAS beman.exemplar)
 
-target_sources(
-    beman.exemplar
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
-)
-
-set_target_properties(
-    beman.exemplar
-    PROPERTIES VERIFY_INTERFACE_HEADER_SETS ${PROJECT_IS_TOP_LEVEL}
-)
+if(BEMAN_EXEMPLAR_USE_MODULES)
+    target_sources(
+        beman.exemplar
+        PUBLIC
+            FILE_SET CXX_MODULES
+            FILE_SET HEADERS
+                BASE_DIRS
+                    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+                    "${CMAKE_CURRENT_BINARY_DIR}/include"
+    )
+    set_target_properties(beman.exemplar PROPERTIES CXX_MODULE_STD ON)
+    target_compile_features(beman.exemplar PUBLIC cxx_std_23)
+else()
+    target_sources(
+        beman.exemplar
+        PUBLIC
+            FILE_SET HEADERS
+                BASE_DIRS
+                    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+                    "${CMAKE_CURRENT_BINARY_DIR}/include"
+    )
+    set_target_properties(
+        beman.exemplar
+        PROPERTIES VERIFY_INTERFACE_HEADER_SETS ${PROJECT_IS_TOP_LEVEL}
+    )
+endif()
 
 add_subdirectory(include/beman/exemplar)
 

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
@@ -44,17 +44,42 @@ jobs:
                       "tests": [
                         "Debug.Default", "Release.Default", "Release.TSan",
                         "Release.MaxSan", "Debug.Werror",
-                        "Debug.Coverage"
+                        "Debug.Coverage", "Debug.-DBEMAN_{{cookiecutter.project_name.upper()}}_USE_MODULES=On"
                       ]
                     }
                   ]
                 },
-                { "cxxversions": ["c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++23"],
+                  "tests": [
+                    { "stdlibs": ["libstdc++"],
+                      "tests": [
+                        "Release.Default", "Debug.-DBEMAN_{{cookiecutter.project_name.upper()}}_USE_MODULES=On"
+                      ]
+                    }
+                  ]
+                },
+                { "cxxversions": ["c++20", "c++17"],
                   "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
                 }
               ]
             },
-            { "versions": ["15", "14", "13"],
+            { "versions": ["15"],
+              "tests": [
+                { "cxxversions": ["c++26", "c++23"],
+                  "tests": [
+                    { "stdlibs": ["libstdc++"],
+                      "tests": [
+                        "Release.Default", "Debug.-DBEMAN_{{cookiecutter.project_name.upper()}}_USE_MODULES=On"
+                      ]
+                    }
+                  ]
+                },
+                { "cxxversions": ["c++20", "c++17"],
+                  "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
+                }
+              ]
+            },
+            { "versions": ["14", "13"],
               "tests": [
                 { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
                   "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
@@ -78,12 +103,22 @@ jobs:
                     { "stdlibs": ["libstdc++", "libc++"],
                       "tests": [
                         "Debug.Default", "Release.Default", "Release.TSan",
-                        "Release.MaxSan", "Debug.Werror"
+                        "Release.MaxSan", "Debug.Werror",
+                        "Debug.-DBEMAN_{{cookiecutter.project_name.upper()}}_USE_MODULES=On"
                       ]
                     }
                   ]
                 },
-                { "cxxversions": ["c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++23"],
+                  "tests": [
+                    { "stdlibs": ["libstdc++", "libc++"],
+                      "tests": [
+                        "Release.Default", "Debug.-DBEMAN_{{cookiecutter.project_name.upper()}}_USE_MODULES=On"
+                      ]
+                    }
+                  ]
+                },
+                { "cxxversions": ["c++20", "c++17"],
                   "tests": [
                     {"stdlibs": ["libstdc++", "libc++"], "tests": ["Release.Default"]}
                   ]
@@ -135,7 +170,10 @@ jobs:
                 { "cxxversions": ["c++23"],
                   "tests": [
                     { "stdlibs": ["stl"],
-                      "tests": ["Debug.Default", "Release.Default", "Release.MaxSan"]
+                      "tests": [
+                        "Debug.Default", "Release.Default", "Release.MaxSan",
+                        "Debug.-DBEMAN_{{cookiecutter.project_name.upper()}}_USE_MODULES=On"
+                      ]
                     }
                   ]
                 }
@@ -148,6 +186,11 @@ jobs:
     uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-vcpkg-ci.yml@1.7.1
     with:
       port_name: beman-{{cookiecutter.project_name.replace('_', '-')}}
+      feature_combinations: |
+        [
+          {"features": {}},
+          {"features": {"modules": true}}
+        ]
 
   create-issue-when-fault:
     needs: [preset-test, build-and-test]

--- a/cookiecutter/{{cookiecutter.project_name}}/CMakeLists.txt
+++ b/cookiecutter/{{cookiecutter.project_name}}/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 cmake_minimum_required(VERSION 3.30...4.3)
 
+include(infra/cmake/enable-experimental-import-std.cmake)
+
 project(
     beman.{{cookiecutter.project_name}}
     DESCRIPTION "{{cookiecutter.description}}"
@@ -27,22 +29,55 @@ option(
     ${PROJECT_IS_TOP_LEVEL}
 )
 
+option(BEMAN_{{cookiecutter.project_name.upper()}}_USE_MODULES "Provide beman.{{cookiecutter.project_name}} as a C++ module" OFF)
+
+if(BEMAN_{{cookiecutter.project_name.upper()}}_USE_MODULES)
+    set(CMAKE_CXX_SCAN_FOR_MODULES ON)
+endif()
+
+configure_file(
+    "${PROJECT_SOURCE_DIR}/include/beman/{{cookiecutter.project_name}}/config_generated.hpp.in"
+    "${PROJECT_BINARY_DIR}/include/beman/{{cookiecutter.project_name}}/config_generated.hpp"
+    @ONLY
+)
+
 # for find of beman_install_library and configure_build_telemetry
 include(infra/cmake/beman-install-library.cmake)
 include(infra/cmake/BuildTelemetryConfig.cmake)
 
-add_library(beman.{{cookiecutter.project_name}} INTERFACE)
+if(BEMAN_{{cookiecutter.project_name.upper()}}_USE_MODULES)
+    add_library(beman.{{cookiecutter.project_name}} STATIC)
+else()
+    add_library(beman.{{cookiecutter.project_name}} INTERFACE)
+endif()
 add_library(beman::{{cookiecutter.project_name}} ALIAS beman.{{cookiecutter.project_name}})
 
-target_sources(
-    beman.{{cookiecutter.project_name}}
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
-)
-
-set_target_properties(
-    beman.{{cookiecutter.project_name}}
-    PROPERTIES VERIFY_INTERFACE_HEADER_SETS ${PROJECT_IS_TOP_LEVEL}
-)
+if(BEMAN_{{cookiecutter.project_name.upper()}}_USE_MODULES)
+    target_sources(
+        beman.{{cookiecutter.project_name}}
+        PUBLIC
+            FILE_SET CXX_MODULES
+            FILE_SET HEADERS
+                BASE_DIRS
+                    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+                    "${CMAKE_CURRENT_BINARY_DIR}/include"
+    )
+    set_target_properties(beman.{{cookiecutter.project_name}} PROPERTIES CXX_MODULE_STD ON)
+    target_compile_features(beman.{{cookiecutter.project_name}} PUBLIC cxx_std_23)
+else()
+    target_sources(
+        beman.{{cookiecutter.project_name}}
+        PUBLIC
+            FILE_SET HEADERS
+                BASE_DIRS
+                    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+                    "${CMAKE_CURRENT_BINARY_DIR}/include"
+    )
+    set_target_properties(
+        beman.{{cookiecutter.project_name}}
+        PROPERTIES VERIFY_INTERFACE_HEADER_SETS ${PROJECT_IS_TOP_LEVEL}
+    )
+endif()
 
 add_subdirectory(include/beman/{{cookiecutter.project_name}})
 

--- a/cookiecutter/{{cookiecutter.project_name}}/examples/CMakeLists.txt
+++ b/cookiecutter/{{cookiecutter.project_name}}/examples/CMakeLists.txt
@@ -28,4 +28,10 @@ foreach(example ${ALL_EXAMPLES})
         beman.{{cookiecutter.project_name}}.examples.${example}
         PRIVATE beman::{{cookiecutter.project_name}}
     )
+    if(BEMAN_{{cookiecutter.project_name.upper()}}_USE_MODULES)
+        set_target_properties(
+            beman.{{cookiecutter.project_name}}.examples.${example}
+            PROPERTIES CXX_MODULE_STD ON
+        )
+    endif()
 endforeach()

--- a/cookiecutter/{{cookiecutter.project_name}}/examples/identity_as_default_projection.cpp
+++ b/cookiecutter/{{cookiecutter.project_name}}/examples/identity_as_default_projection.cpp
@@ -3,14 +3,19 @@
 // This example demonstrates the usage of beman::{{cookiecutter.project_name}}::identity as a default projection in a range-printer.
 // Requires: range support (C++20) and std::identity support (C++20).
 
+#include <beman/{{cookiecutter.project_name}}/config.hpp>
 #include <beman/{{cookiecutter.project_name}}/identity.hpp>
 
-#include <algorithm>
-#include <functional> // std::identity
-#include <iostream>
-#include <ranges>
-#include <string>
-#include <vector>
+#if BEMAN_{{cookiecutter.project_name.upper()}}_USE_MODULES()
+import std;
+#else
+    #include <algorithm>
+    #include <functional> // std::identity
+    #include <iostream>
+    #include <ranges>
+    #include <string>
+    #include <vector>
+#endif
 
 namespace exe = beman::{{cookiecutter.project_name}};
 

--- a/cookiecutter/{{cookiecutter.project_name}}/examples/identity_direct_usage.cpp
+++ b/cookiecutter/{{cookiecutter.project_name}}/examples/identity_direct_usage.cpp
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 {% set identity = "identity" if cookiecutter._generating_exemplar else "todo" %}
 
+#include <beman/{{cookiecutter.project_name}}/config.hpp>
 #include <beman/{{cookiecutter.project_name}}/{{identity}}.hpp>
 
 {% if cookiecutter._generating_exemplar %}
-#include <iostream>
+#if BEMAN_{{cookiecutter.project_name.upper()}}_USE_MODULES()
+import std;
+#else
+    #include <iostream>
+#endif
 
 namespace exe = beman::{{cookiecutter.project_name}};
 

--- a/cookiecutter/{{cookiecutter.project_name}}/include/beman/{{cookiecutter.project_name}}/CMakeLists.txt
+++ b/cookiecutter/{{cookiecutter.project_name}}/include/beman/{{cookiecutter.project_name}}/CMakeLists.txt
@@ -1,7 +1,27 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 {% set identity = "identity" if cookiecutter._generating_exemplar else "todo" %}
 
-target_sources(
-    beman.{{cookiecutter.project_name}}
-    PUBLIC FILE_SET HEADERS FILES {{cookiecutter.project_name}}.hpp {{identity}}.hpp
-)
+if(BEMAN_{{cookiecutter.project_name.upper()}}_USE_MODULES)
+    target_sources(
+        beman.{{cookiecutter.project_name}}
+        PUBLIC
+            FILE_SET CXX_MODULES FILES {{cookiecutter.project_name}}.cppm
+            FILE_SET HEADERS
+                FILES
+                    config.hpp
+                    {{cookiecutter.project_name}}.hpp
+                    {{identity}}.hpp
+                    "${PROJECT_BINARY_DIR}/include/beman/{{cookiecutter.project_name}}/config_generated.hpp"
+    )
+else()
+    target_sources(
+        beman.{{cookiecutter.project_name}}
+        PUBLIC
+            FILE_SET HEADERS
+                FILES
+                    config.hpp
+                    {{cookiecutter.project_name}}.hpp
+                    {{identity}}.hpp
+                    "${PROJECT_BINARY_DIR}/include/beman/{{cookiecutter.project_name}}/config_generated.hpp"
+    )
+endif()

--- a/cookiecutter/{{cookiecutter.project_name}}/include/beman/{{cookiecutter.project_name}}/config.hpp
+++ b/cookiecutter/{{cookiecutter.project_name}}/include/beman/{{cookiecutter.project_name}}/config.hpp
@@ -1,0 +1,10 @@
+#ifndef BEMAN_{{cookiecutter.project_name.upper()}}_CONFIG_HPP
+#define BEMAN_{{cookiecutter.project_name.upper()}}_CONFIG_HPP
+
+#if !defined(__has_include) || __has_include(<beman/{{cookiecutter.project_name}}/config_generated.hpp>)
+    #include <beman/{{cookiecutter.project_name}}/config_generated.hpp>
+#else
+    #define BEMAN_{{cookiecutter.project_name.upper()}}_USE_MODULES() 0
+#endif
+
+#endif

--- a/cookiecutter/{{cookiecutter.project_name}}/include/beman/{{cookiecutter.project_name}}/config_generated.hpp.in
+++ b/cookiecutter/{{cookiecutter.project_name}}/include/beman/{{cookiecutter.project_name}}/config_generated.hpp.in
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef BEMAN_{{cookiecutter.project_name.upper()}}_CONFIG_GENERATED_HPP
+#define BEMAN_{{cookiecutter.project_name.upper()}}_CONFIG_GENERATED_HPP
+
+#cmakedefine01 BEMAN_{{cookiecutter.project_name.upper()}}_USE_MODULES()
+
+#endif

--- a/cookiecutter/{{cookiecutter.project_name}}/include/beman/{{cookiecutter.project_name}}/identity.hpp
+++ b/cookiecutter/{{cookiecutter.project_name}}/include/beman/{{cookiecutter.project_name}}/identity.hpp
@@ -4,25 +4,35 @@
 #ifndef BEMAN_{{cookiecutter.project_name.upper()}}_{{identity.upper()}}_HPP
 #define BEMAN_{{cookiecutter.project_name.upper()}}_{{identity.upper()}}_HPP
 
-{% if cookiecutter._generating_exemplar %}
-// C++ Standard Library: std::identity equivalent.
-// See https://eel.is/c++draft/func.identity:
-//
-// 22.10.12 Class identity  [func.identity]
-//
-// struct identity {
-//   template<class T>
-//     constexpr T&& operator()(T&& t) const noexcept;
-//
-//   using is_transparent = unspecified;
-// };
-//
-// template<class T>
-//   constexpr T&& operator()(T&& t) const noexcept;
-//
-// Effects: Equivalent to: return std::forward<T>(t);
+#include <beman/{{cookiecutter.project_name}}/config.hpp>
 
-#include <utility> // std::forward
+#if BEMAN_{{cookiecutter.project_name.upper()}}_USE_MODULES() && !defined(BEMAN_{{cookiecutter.project_name.upper()}}_INCLUDED_FROM_INTERFACE_UNIT)
+
+import beman.{{cookiecutter.project_name}};
+
+#else
+
+{% if cookiecutter._generating_exemplar %}
+    // C++ Standard Library: std::identity equivalent.
+    // See https://eel.is/c++draft/func.identity:
+    //
+    // 22.10.12 Class identity  [func.identity]
+    //
+    // struct identity {
+    //   template<class T>
+    //     constexpr T&& operator()(T&& t) const noexcept;
+    //
+    //   using is_transparent = unspecified;
+    // };
+    //
+    // template<class T>
+    //   constexpr T&& operator()(T&& t) const noexcept;
+    //
+    // Effects: Equivalent to: return std::forward<T>(t);
+
+    #if !BEMAN_EXEMPLAR_USE_MODULES()
+        #include <utility> // std::forward
+    #endif
 
 {% endif %}
 namespace beman::{{cookiecutter.project_name}} {
@@ -46,5 +56,8 @@ struct identity {
 
 {% endif %}
 } // namespace beman::{{cookiecutter.project_name}}
+
+#endif // BEMAN_{{cookiecutter.project_name.upper()}}_USE_MODULES() &&
+       // !defined(BEMAN_{{cookiecutter.project_name.upper()}}_INCLUDED_FROM_INTERFACE_UNIT)
 
 #endif // BEMAN_{{cookiecutter.project_name.upper()}}_{{identity.upper()}}_HPP

--- a/cookiecutter/{{cookiecutter.project_name}}/include/beman/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}.cppm
+++ b/cookiecutter/{{cookiecutter.project_name}}/include/beman/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}.cppm
@@ -1,0 +1,11 @@
+export module beman.{{cookiecutter.project_name}};
+
+import std;
+
+#define BEMAN_{{cookiecutter.project_name.upper()}}_INCLUDED_FROM_INTERFACE_UNIT
+export {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winclude-angled-in-module-purview"
+#include <beman/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}.hpp>
+#pragma clang diagnostic pop
+}

--- a/cookiecutter/{{cookiecutter.project_name}}/include/beman/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}.hpp
+++ b/cookiecutter/{{cookiecutter.project_name}}/include/beman/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}.hpp
@@ -4,6 +4,17 @@
 #ifndef BEMAN_{{cookiecutter.project_name.upper()}}_{{cookiecutter.project_name.upper()}}_HPP
 #define BEMAN_{{cookiecutter.project_name.upper()}}_{{cookiecutter.project_name.upper()}}_HPP
 
-#include <beman/{{cookiecutter.project_name}}/{{identity}}.hpp>
+#include <beman/{{cookiecutter.project_name}}/config.hpp>
+
+#if BEMAN_{{cookiecutter.project_name.upper()}}_USE_MODULES() && !defined(BEMAN_{{cookiecutter.project_name.upper()}}_INCLUDED_FROM_INTERFACE_UNIT)
+
+import beman.{{cookiecutter.project_name}};
+
+#else
+
+    #include <beman/{{cookiecutter.project_name}}/{{identity}}.hpp>
+
+#endif // BEMAN_{{cookiecutter.project_name.upper()}}_USE_MODULES() &&
+       // !defined(BEMAN_{{cookiecutter.project_name.upper()}}_INCLUDED_FROM_INTERFACE_UNIT)
 
 #endif // BEMAN_{{cookiecutter.project_name.upper()}}_{{cookiecutter.project_name.upper()}}_HPP

--- a/cookiecutter/{{cookiecutter.project_name}}/port/portfile.cmake.in
+++ b/cookiecutter/{{cookiecutter.project_name}}/port/portfile.cmake.in
@@ -7,9 +7,16 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        modules   BEMAN_{{cookiecutter.project_name.upper()}}_USE_MODULES
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DBEMAN_{{cookiecutter.project_name.upper()}}_BUILD_TESTS=OFF
         -DBEMAN_{{cookiecutter.project_name.upper()}}_BUILD_EXAMPLES=OFF
 )
@@ -21,9 +28,11 @@ vcpkg_cmake_config_fixup(
     CONFIG_PATH lib/cmake/beman.{{cookiecutter.project_name}}
 )
 
-file(REMOVE_RECURSE
-    "${CURRENT_PACKAGES_DIR}/debug"
-    "${CURRENT_PACKAGES_DIR}/lib"
-)
+if(NOT "modules" IN_LIST FEATURES)
+    file(REMOVE_RECURSE
+        "${CURRENT_PACKAGES_DIR}/debug"
+        "${CURRENT_PACKAGES_DIR}/lib"
+    )
+endif()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/cookiecutter/{{cookiecutter.project_name}}/port/vcpkg.json.in
+++ b/cookiecutter/{{cookiecutter.project_name}}/port/vcpkg.json.in
@@ -13,5 +13,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "modules": {
+      "description": "Provide beman.{{cookiecutter.project_name}} as a C++ module"
+    }
+  }
 }

--- a/cookiecutter/{{cookiecutter.project_name}}/tests/beman/{{cookiecutter.project_name}}/CMakeLists.txt
+++ b/cookiecutter/{{cookiecutter.project_name}}/tests/beman/{{cookiecutter.project_name}}/CMakeLists.txt
@@ -17,6 +17,12 @@ target_link_libraries(
     PRIVATE beman::{{cookiecutter.project_name}} Catch2::Catch2WithMain
 {% endif %}
 )
+if(BEMAN_EXEMPLAR_USE_MODULES)
+    set_target_properties(
+        beman.{{cookiecutter.project_name}}.tests.{{identity}}
+        PROPERTIES CXX_MODULE_STD ON
+    )
+endif()
 
 {% if cookiecutter.unit_test_library == "gtest" %}
 include(GoogleTest)

--- a/cookiecutter/{{cookiecutter.project_name}}/tests/beman/{{cookiecutter.project_name}}/identity.test.cpp
+++ b/cookiecutter/{{cookiecutter.project_name}}/tests/beman/{{cookiecutter.project_name}}/identity.test.cpp
@@ -1,17 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 {% set identity = "identity" if cookiecutter._generating_exemplar else "todo" %}
 
-#include <beman/{{cookiecutter.project_name}}/{{identity}}.hpp>
-
+#include <beman/{{cookiecutter.project_name}}/config.hpp>
 {% if cookiecutter.unit_test_library == "gtest" %}
 #include <gtest/gtest.h>
 {% elif cookiecutter.unit_test_library == "catch2" %}
 #include <catch2/catch_all.hpp>
 {% endif %}
+#include <beman/{{cookiecutter.project_name}}/{{identity}}.hpp>
 
 {% if cookiecutter._generating_exemplar %}
-#include <algorithm>
-#include <functional>
+#if BEMAN_EXEMPLAR_USE_MODULES()
+import std;
+#else
+    #include <algorithm>
+    #include <functional>
+#endif
 
 namespace exe = beman::{{cookiecutter.project_name}};
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -24,4 +24,10 @@ foreach(example ${ALL_EXAMPLES})
         beman.exemplar.examples.${example}
         PRIVATE beman::exemplar
     )
+    if(BEMAN_EXEMPLAR_USE_MODULES)
+        set_target_properties(
+            beman.exemplar.examples.${example}
+            PROPERTIES CXX_MODULE_STD ON
+        )
+    endif()
 endforeach()

--- a/examples/identity_as_default_projection.cpp
+++ b/examples/identity_as_default_projection.cpp
@@ -3,14 +3,19 @@
 // This example demonstrates the usage of beman::exemplar::identity as a default projection in a range-printer.
 // Requires: range support (C++20) and std::identity support (C++20).
 
+#include <beman/exemplar/config.hpp>
 #include <beman/exemplar/identity.hpp>
 
-#include <algorithm>
-#include <functional> // std::identity
-#include <iostream>
-#include <ranges>
-#include <string>
-#include <vector>
+#if BEMAN_EXEMPLAR_USE_MODULES()
+import std;
+#else
+    #include <algorithm>
+    #include <functional> // std::identity
+    #include <iostream>
+    #include <ranges>
+    #include <string>
+    #include <vector>
+#endif
 
 namespace exe = beman::exemplar;
 

--- a/examples/identity_direct_usage.cpp
+++ b/examples/identity_direct_usage.cpp
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <beman/exemplar/config.hpp>
 #include <beman/exemplar/identity.hpp>
 
-#include <iostream>
+#if BEMAN_EXEMPLAR_USE_MODULES()
+import std;
+#else
+    #include <iostream>
+#endif
 
 namespace exe = beman::exemplar;
 

--- a/include/beman/exemplar/CMakeLists.txt
+++ b/include/beman/exemplar/CMakeLists.txt
@@ -1,6 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-target_sources(
-    beman.exemplar
-    PUBLIC FILE_SET HEADERS FILES exemplar.hpp identity.hpp
-)
+if(BEMAN_EXEMPLAR_USE_MODULES)
+    target_sources(
+        beman.exemplar
+        PUBLIC
+            FILE_SET CXX_MODULES FILES exemplar.cppm
+            FILE_SET HEADERS
+                FILES
+                    config.hpp
+                    exemplar.hpp
+                    identity.hpp
+                    "${PROJECT_BINARY_DIR}/include/beman/exemplar/config_generated.hpp"
+    )
+else()
+    target_sources(
+        beman.exemplar
+        PUBLIC
+            FILE_SET HEADERS
+                FILES
+                    config.hpp
+                    exemplar.hpp
+                    identity.hpp
+                    "${PROJECT_BINARY_DIR}/include/beman/exemplar/config_generated.hpp"
+    )
+endif()

--- a/include/beman/exemplar/config.hpp
+++ b/include/beman/exemplar/config.hpp
@@ -1,0 +1,10 @@
+#ifndef BEMAN_EXEMPLAR_CONFIG_HPP
+#define BEMAN_EXEMPLAR_CONFIG_HPP
+
+#if !defined(__has_include) || __has_include(<beman/exemplar/config_generated.hpp>)
+    #include <beman/exemplar/config_generated.hpp>
+#else
+    #define BEMAN_EXEMPLAR_USE_MODULES() 0
+#endif
+
+#endif

--- a/include/beman/exemplar/config_generated.hpp.in
+++ b/include/beman/exemplar/config_generated.hpp.in
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef BEMAN_EXEMPLAR_CONFIG_GENERATED_HPP
+#define BEMAN_EXEMPLAR_CONFIG_GENERATED_HPP
+
+#cmakedefine01 BEMAN_EXEMPLAR_USE_MODULES()
+
+#endif

--- a/include/beman/exemplar/exemplar.cppm
+++ b/include/beman/exemplar/exemplar.cppm
@@ -1,0 +1,11 @@
+export module beman.exemplar;
+
+import std;
+
+#define BEMAN_EXEMPLAR_INCLUDED_FROM_INTERFACE_UNIT
+export {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winclude-angled-in-module-purview"
+#include <beman/exemplar/exemplar.hpp>
+#pragma clang diagnostic pop
+}

--- a/include/beman/exemplar/exemplar.hpp
+++ b/include/beman/exemplar/exemplar.hpp
@@ -3,6 +3,17 @@
 #ifndef BEMAN_EXEMPLAR_EXEMPLAR_HPP
 #define BEMAN_EXEMPLAR_EXEMPLAR_HPP
 
-#include <beman/exemplar/identity.hpp>
+#include <beman/exemplar/config.hpp>
+
+#if BEMAN_EXEMPLAR_USE_MODULES() && !defined(BEMAN_EXEMPLAR_INCLUDED_FROM_INTERFACE_UNIT)
+
+import beman.exemplar;
+
+#else
+
+    #include <beman/exemplar/identity.hpp>
+
+#endif // BEMAN_EXEMPLAR_USE_MODULES() &&
+       // !defined(BEMAN_EXEMPLAR_INCLUDED_FROM_INTERFACE_UNIT)
 
 #endif // BEMAN_EXEMPLAR_EXEMPLAR_HPP

--- a/include/beman/exemplar/identity.hpp
+++ b/include/beman/exemplar/identity.hpp
@@ -3,24 +3,34 @@
 #ifndef BEMAN_EXEMPLAR_IDENTITY_HPP
 #define BEMAN_EXEMPLAR_IDENTITY_HPP
 
-// C++ Standard Library: std::identity equivalent.
-// See https://eel.is/c++draft/func.identity:
-//
-// 22.10.12 Class identity  [func.identity]
-//
-// struct identity {
-//   template<class T>
-//     constexpr T&& operator()(T&& t) const noexcept;
-//
-//   using is_transparent = unspecified;
-// };
-//
-// template<class T>
-//   constexpr T&& operator()(T&& t) const noexcept;
-//
-// Effects: Equivalent to: return std::forward<T>(t);
+#include <beman/exemplar/config.hpp>
 
-#include <utility> // std::forward
+#if BEMAN_EXEMPLAR_USE_MODULES() && !defined(BEMAN_EXEMPLAR_INCLUDED_FROM_INTERFACE_UNIT)
+
+import beman.exemplar;
+
+#else
+
+    // C++ Standard Library: std::identity equivalent.
+    // See https://eel.is/c++draft/func.identity:
+    //
+    // 22.10.12 Class identity  [func.identity]
+    //
+    // struct identity {
+    //   template<class T>
+    //     constexpr T&& operator()(T&& t) const noexcept;
+    //
+    //   using is_transparent = unspecified;
+    // };
+    //
+    // template<class T>
+    //   constexpr T&& operator()(T&& t) const noexcept;
+    //
+    // Effects: Equivalent to: return std::forward<T>(t);
+
+    #if !BEMAN_EXEMPLAR_USE_MODULES()
+        #include <utility> // std::forward
+    #endif
 
 namespace beman::exemplar {
 
@@ -38,5 +48,8 @@ struct identity {
 };
 
 } // namespace beman::exemplar
+
+#endif // BEMAN_EXEMPLAR_USE_MODULES() &&
+       // !defined(BEMAN_EXEMPLAR_INCLUDED_FROM_INTERFACE_UNIT)
 
 #endif // BEMAN_EXEMPLAR_IDENTITY_HPP

--- a/port/portfile.cmake.in
+++ b/port/portfile.cmake.in
@@ -7,9 +7,16 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        modules   BEMAN_EXEMPLAR_USE_MODULES
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DBEMAN_EXEMPLAR_BUILD_TESTS=OFF
         -DBEMAN_EXEMPLAR_BUILD_EXAMPLES=OFF
 )
@@ -21,9 +28,11 @@ vcpkg_cmake_config_fixup(
     CONFIG_PATH lib/cmake/beman.exemplar
 )
 
-file(REMOVE_RECURSE
-    "${CURRENT_PACKAGES_DIR}/debug"
-    "${CURRENT_PACKAGES_DIR}/lib"
-)
+if(NOT "modules" IN_LIST FEATURES)
+    file(REMOVE_RECURSE
+        "${CURRENT_PACKAGES_DIR}/debug"
+        "${CURRENT_PACKAGES_DIR}/lib"
+    )
+endif()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/port/vcpkg.json.in
+++ b/port/vcpkg.json.in
@@ -13,5 +13,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "modules": {
+      "description": "Provide beman.exemplar as a C++ module"
+    }
+  }
 }

--- a/tests/beman/exemplar/CMakeLists.txt
+++ b/tests/beman/exemplar/CMakeLists.txt
@@ -8,6 +8,12 @@ target_link_libraries(
     beman.exemplar.tests.identity
     PRIVATE beman::exemplar GTest::gtest_main
 )
+if(BEMAN_EXEMPLAR_USE_MODULES)
+    set_target_properties(
+        beman.exemplar.tests.identity
+        PROPERTIES CXX_MODULE_STD ON
+    )
+endif()
 
 include(GoogleTest)
 gtest_discover_tests(beman.exemplar.tests.identity DISCOVERY_TIMEOUT 60)

--- a/tests/beman/exemplar/identity.test.cpp
+++ b/tests/beman/exemplar/identity.test.cpp
@@ -1,11 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <beman/exemplar/config.hpp>
+#include <gtest/gtest.h>
 #include <beman/exemplar/identity.hpp>
 
-#include <gtest/gtest.h>
-
-#include <algorithm>
-#include <functional>
+#if BEMAN_EXEMPLAR_USE_MODULES()
+import std;
+#else
+    #include <algorithm>
+    #include <functional>
+#endif
 
 namespace exe = beman::exemplar;
 


### PR DESCRIPTION
This approach to modules implementation is based on the approach used to implement module support for Boost by Rubén Pérez (anarthal). See his documentation:
https://github.com/anarthal/boost-cmake/blob/e29bc2a5bd3493d353bf597610d4b32b5a11d0dc/modules.md

The basic idea is that every header is in one of three modes:

- Normal mode (the user included the header, and we aren't building with modules)
  - In this case, the macros configure the header so its contents are the same as their pre-refactor state
- included-from-interface-unit-mode
  - Here, we're inserting all the code from the header into an export block inside the implementation of the .cppm file, so this mode is the same as normal mode except that we ifdef out any standard library includes, or any other dependencies that the .cppm file is bringing in via module
- Compatibility header mode
  - The project is built as a module, but the consumer still is bringing the dependency in by writing #include <{...}.hpp>. In this case the header #ifdefs out everything except a simple import beman.foo statement.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
