### PR TITLE
Fix cookiecutter mismatch with vcpkg-configuration.json

### DIFF
--- a/cookiecutter/{{cookiecutter.project_name}}/vcpkg-configuration.json
+++ b/cookiecutter/{{cookiecutter.project_name}}/vcpkg-configuration.json
@@ -2,13 +2,13 @@
   "default-registry": {
     "kind": "git",
     "repository": "https://github.com/microsoft/vcpkg.git",
-    "baseline": "80f9bcfa455e875d9c1bf7a7c6692d7e1e481061"
+    "baseline": "522253caf47268c1724f486a035e927a42a90092"
   },
   "registries": [
     {
       "kind": "git",
       "repository": "https://github.com/bemanproject/vcpkg-registry.git",
-      "baseline": "5195f94f2b550163917c1152180fc59bbd760556",
+      "baseline": "28992b34d1e39368f5d1214a557fd61949de39fb",
       "packages": ["beman-*"]
     }
   ]


### PR DESCRIPTION
129d0a053992d562b8afdead76cc9d8f4fa4ddd6 neglected to apply the change to the cookiecutter template.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
