### PR TITLE
Bump infra/ beman-submodule to latest main

### DIFF
--- a/cookiecutter/{{cookiecutter.project_name}}/infra/.beman_submodule
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/.beman_submodule
@@ -1,3 +1,3 @@
 [beman_submodule]
 remote=https://github.com/bemanproject/infra.git
-commit_hash=66b4f0cdf527cb66bfe2f009f0d2b0ceb56d2cd0
+commit_hash=eb7b7c3688bd8f26ab0c145e3147df9a8f2ec8ce

--- a/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/enable-experimental-import-std.cmake
+++ b/cookiecutter/{{cookiecutter.project_name}}/infra/cmake/enable-experimental-import-std.cmake
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 if(CMAKE_VERSION VERSION_EQUAL "3.30.0")
     set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD
         "0e5b6991-d74f-4b3d-a41c-cf096e0b2508"

--- a/infra/.beman_submodule
+++ b/infra/.beman_submodule
@@ -1,3 +1,3 @@
 [beman_submodule]
 remote=https://github.com/bemanproject/infra.git
-commit_hash=66b4f0cdf527cb66bfe2f009f0d2b0ceb56d2cd0
+commit_hash=eb7b7c3688bd8f26ab0c145e3147df9a8f2ec8ce

--- a/infra/cmake/enable-experimental-import-std.cmake
+++ b/infra/cmake/enable-experimental-import-std.cmake
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 if(CMAKE_VERSION VERSION_EQUAL "3.30.0")
     set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD
         "0e5b6991-d74f-4b3d-a41c-cf096e0b2508"


### PR DESCRIPTION
This just adds the missing SPDX-License-Identifier to enable-experimental-import-std.cmake.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
