### PR TITLE
Add kill on push as default

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -11,6 +11,10 @@ on:
   schedule:
     - cron: '30 15 * * 6'
 
+concurrency:
+  group: ${{format('{0}:{1}', github.repository, github.ref)}}
+  cancel-in-progress: true
+
 jobs:
   beman-submodule-check:
     uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@1.7.2

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
@@ -11,6 +11,11 @@ on:
   schedule:
     - cron: '{% if cookiecutter._ci_tests_cron %}{{ cookiecutter._ci_tests_cron }}{% else %}{{ range(0, 60) | random }} {{ range(13, 18) | random }} * * {{ range(0, 7) | random }}{% endif %}'
 
+concurrency:
+  group: {% raw %}${{format('{0}:{1}', github.repository, github.ref)}}{% endraw %}
+
+  cancel-in-progress: true
+
 jobs:
   beman-submodule-check:
     uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@1.7.2


### PR DESCRIPTION
Without this as you add a commit to a PR the old runners will continue and new ones will get spun up. This change kills all the runners in progress before the commit was added.