### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,14 +14,14 @@ repos:
     # This brings in a portable version of clang-format.
     # See also: https://github.com/ssciwr/clang-format-wheel
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v22.1.4
+    rev: v22.1.5
     hooks:
     - id: clang-format
       types_or: [c++, c]
 
     # CMake linting and formatting
   - repo: https://github.com/BlankSpruce/gersemi-pre-commit
-    rev: 0.27.2
+    rev: 0.27.6
     hooks:
     - id: gersemi
       name: CMake linting

--- a/cookiecutter/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -14,14 +14,14 @@ repos:
     # This brings in a portable version of clang-format.
     # See also: https://github.com/ssciwr/clang-format-wheel
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v22.1.4
+    rev: v22.1.5
     hooks:
     - id: clang-format
       types_or: [c++, c]
 
     # CMake linting and formatting
   - repo: https://github.com/BlankSpruce/gersemi-pre-commit
-    rev: 0.27.2
+    rev: 0.27.6
     hooks:
     - id: gersemi
       name: CMake linting
@@ -43,7 +43,7 @@ repos:
 {% if not cookiecutter._generating_exemplar %}
     # Beman Standard checking via beman-tidy
   - repo: https://github.com/bemanproject/beman-tidy
-    rev: v0.3.1
+    rev: v0.5.0
     hooks:
     - id: beman-tidy
 


### PR DESCRIPTION
This updates cookiecutter to use version 0.5.0 of beman-tidy, which fixes the SPDX license identifier check to accept comments anywhere within the first 25 lines.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
