### PR TITLE
Remove redundant include search path modification note from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,9 +249,3 @@ include an appropriate `beman.exemplar` header from your source code.
 ```c++
 #include <beman/exemplar/exemplar.hpp>
 ```
-
-> [!NOTE]
->
-> `beman.exemplar` headers are to be included with the `beman/exemplar/` prefix.
-> Altering include search paths to spell the include target another way (e.g.
-> `#include <exemplar.hpp>`) is unsupported.

--- a/cookiecutter/{{cookiecutter.project_name}}/README.md
+++ b/cookiecutter/{{cookiecutter.project_name}}/README.md
@@ -265,9 +265,3 @@ include an appropriate `beman.{{cookiecutter.project_name}}` header from your so
 ```c++
 #include <beman/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}.hpp>
 ```
-
-> [!NOTE]
->
-> `beman.{{cookiecutter.project_name}}` headers are to be included with the `beman/{{cookiecutter.project_name}}/` prefix.
-> Altering include search paths to spell the include target another way (e.g.
-> `#include <{{cookiecutter.project_name}}.hpp>`) is unsupported.


### PR DESCRIPTION
That altering the include search path to something the library doesn't expect will cause problems is somewhat obvious and not important enough of a fact to live in the README.md.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
