### PR TITLE
Fix .beman-tidy.yaml null values in exemplar template

### DIFF
--- a/.beman-tidy.yaml
+++ b/.beman-tidy.yaml
@@ -7,4 +7,4 @@
 disabled_rules:
   - readme.title
 ignored_paths:
-    # None
+  - infra/

--- a/cookiecutter/{{cookiecutter.project_name}}/.beman-tidy.yaml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.beman-tidy.yaml
@@ -8,8 +8,7 @@
 disabled_rules:
   - readme.title
 {% else %}
-disabled_rules:
-    # None
+disabled_rules: []
 {% endif %}
 ignored_paths:
-    # None
+  - infra/

--- a/cookiecutter/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
 {% if not cookiecutter._generating_exemplar %}
     # Beman Standard checking via beman-tidy
   - repo: https://github.com/bemanproject/beman-tidy
-    rev: v0.5.1
+    rev: v0.5.2
     hooks:
     - id: beman-tidy
 


### PR DESCRIPTION
## Summary

The exemplar template uses `# None` under `disabled_rules` and `ignored_paths`, which YAML parses as explicit `null`. In beman-tidy v0.5.x this crashes at runtime:

```
TypeError: can only concatenate list (not "NoneType") to list
```

because `.get("ignored_paths", [])` returns `None` when the key exists with a null value.

## Changes

- Root `.beman-tidy.yaml`: `ignored_paths: [infra/]`
- Cookiecutter template: `disabled_rules: []` (non-exemplar path) and `ignored_paths: [infra/]`
- Cookiecutter `.pre-commit-config.yaml`: bump `beman-tidy` to **v0.5.2**

## Test plan

- [x] Verified parsed YAML is `{'disabled_rules': [], 'ignored_paths': ['infra/']}` for default cookiecutter output
- [ ] CI green