### PR TITLE
fix cookiecutter: valid disabled_rules for run-on-exemplar CI

### DIFF
--- a/cookiecutter/{{cookiecutter.project_name}}/.beman-tidy.yaml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.beman-tidy.yaml
@@ -8,7 +8,10 @@
 disabled_rules:
   - readme.title
 {% else %}
-disabled_rules: []
+# TODO: These rules are temporarily disabled for fresh new libraries. Please fix and enable them afterwards.
+disabled_rules:
+  - readme.implements
+  - release.godbolt_trunk_version
 {% endif %}
 ignored_paths:
   - infra/


### PR DESCRIPTION
## Summary
Fixes the YAML parse error in [beman-tidy run-on-exemplar](https://github.com/bemanproject/beman-tidy/blob/main/.github/workflows/run-on-exemplar.yml) when stamping a new library via `stamp.sh`.

**Root cause:** cookiecutter output used `disabled_rules: []`. The beman-tidy CI step appends rules with `sed` after `disabled_rules:`, producing invalid YAML:

```yaml
disabled_rules: []
  - release.godbolt_trunk_version
  - readme.implements
```

**Fix:** stamped repos now emit a proper list with the rules CI expects:

```yaml
disabled_rules:
  - release.godbolt_trunk_version
  - readme.implements
```

## Test plan
- [x] Verified YAML stays valid even if CI `sed` still runs (duplicates only, no parse error)
- [ ] Merge and re-run beman-tidy `Run on beman.exemplar` on check PRs