### PR TITLE
docs: document BEMAN_EXEMPLAR_BUILD_EXAMPLES in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ This project requires at least the following to build:
 You can disable building tests by setting CMake option `BEMAN_EXEMPLAR_BUILD_TESTS` to
 `OFF` when configuring the project.
 
+You can disable building examples by setting CMake option `BEMAN_EXEMPLAR_BUILD_EXAMPLES` to
+`OFF` when configuring the project.
+
 ### Supported Platforms
 
 | Compiler   | Version | C++ Standards | Standard Library  |

--- a/cookiecutter/{{cookiecutter.project_name}}/README.md
+++ b/cookiecutter/{{cookiecutter.project_name}}/README.md
@@ -158,6 +158,9 @@ This project requires at least the following to build:
 You can disable building tests by setting CMake option `BEMAN_{{cookiecutter.project_name.upper()}}_BUILD_TESTS` to
 `OFF` when configuring the project.
 
+You can disable building examples by setting CMake option `BEMAN_{{cookiecutter.project_name.upper()}}_BUILD_EXAMPLES` to
+`OFF` when configuring the project.
+
 ### Supported Platforms
 
 | Compiler   | Version | C++ Standards | Standard Library  |


### PR DESCRIPTION
Related to https://github.com/bemanproject/beman-tidy/pull/358

Add README guidance for disabling examples via `BEMAN_EXEMPLAR_BUILD_EXAMPLES`, matching the existing `BEMAN_EXEMPLAR_BUILD_TESTS` phrase.