### PR TITLE
Fix check_cookiecutter.sh hashbang

### DIFF
--- a/cookiecutter/check_cookiecutter.sh
+++ b/cookiecutter/check_cookiecutter.sh
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 set -euo pipefail
 


### PR DESCRIPTION
This was broken by commit 436eea402499e1599b2f3f0e7570ddb695a3eab4 (https://github.com/bemanproject/exemplar/pull/375) adding an SPDX-License-Identifier commit on line 1.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
