### PR TITLE
Bump gtest and catch2 dependency versions in lockfile.json

### DIFF
--- a/cookiecutter/{{cookiecutter.project_name}}/lockfile.json
+++ b/cookiecutter/{{cookiecutter.project_name}}/lockfile.json
@@ -5,7 +5,7 @@
       "name": "googletest",
       "package_name": "GTest",
       "git_repository": "https://github.com/google/googletest.git",
-      "git_tag": "6910c9d9165801d8827d628cb72eb7ea9dd538c5",
+      "git_tag": "52eb8108c5bdec04579160ae17225d66034bd723",
       "cmake_args": {
         "INSTALL_GTEST": "OFF"
       }
@@ -15,7 +15,7 @@
       "name": "Catch2",
       "package_name": "Catch2",
       "git_repository": "https://github.com/catchorg/Catch2.git",
-      "git_tag": "25319fd3047c6bdcf3c0170e76fa526c77f99ca9"
+      "git_tag": "8b08d4d79514f45f7e4ce2a607ac9c94e920d1bb"
     }
 {% endif %}
   ]

--- a/lockfile.json
+++ b/lockfile.json
@@ -4,7 +4,7 @@
       "name": "googletest",
       "package_name": "GTest",
       "git_repository": "https://github.com/google/googletest.git",
-      "git_tag": "6910c9d9165801d8827d628cb72eb7ea9dd538c5",
+      "git_tag": "52eb8108c5bdec04579160ae17225d66034bd723",
       "cmake_args": {
         "INSTALL_GTEST": "OFF"
       }


### PR DESCRIPTION
This uses the commit hashes for versions 1.17.0 and 3.15.3, respectively, rather than the git tags themselves, as a security best practice.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
