### PR TITLE
Bump workflows to 1.7.4

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -17,10 +17,10 @@ concurrency:
 
 jobs:
   beman-submodule-check:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@1.7.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@1.7.4
 
   preset-test:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-preset-test.yml@1.7.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-preset-test.yml@1.7.4
     with:
       matrix_config: >
         [
@@ -35,7 +35,7 @@ jobs:
         ]
 
   build-and-test:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-build-and-test.yml@1.7.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-build-and-test.yml@1.7.4
     with:
       matrix_config: >
         {
@@ -187,7 +187,7 @@ jobs:
         }
 
   vcpkg-ci:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-vcpkg-ci.yml@1.7.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-vcpkg-ci.yml@1.7.4
     with:
       port_name: beman-exemplar
       feature_combinations: |
@@ -199,4 +199,4 @@ jobs:
   create-issue-when-fault:
     needs: [preset-test, build-and-test]
     if: failure() && github.event_name == 'schedule'
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.7.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.7.4

--- a/.github/workflows/pre-commit-check.yml
+++ b/.github/workflows/pre-commit-check.yml
@@ -17,4 +17,4 @@ permissions:
 
 jobs:
   pre-commit:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-pre-commit.yml@1.7.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-pre-commit.yml@1.7.4

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   auto-update-pre-commit:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-update-pre-commit.yml@1.7.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-update-pre-commit.yml@1.7.4
     secrets:
       APP_ID: ${{ secrets.AUTO_PR_BOT_APP_ID }}
       PRIVATE_KEY: ${{ secrets.AUTO_PR_BOT_PRIVATE_KEY }}

--- a/.github/workflows/vcpkg-release.yml
+++ b/.github/workflows/vcpkg-release.yml
@@ -6,7 +6,7 @@ on:
     types: [published]
 jobs:
   vcpkg-release:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-vcpkg-release.yml@1.7.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-vcpkg-release.yml@1.7.4
     with:
       port_name: beman-exemplar
     secrets:

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/ci_tests.yml
@@ -18,10 +18,10 @@ concurrency:
 
 jobs:
   beman-submodule-check:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@1.7.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@1.7.4
 
   preset-test:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-preset-test.yml@1.7.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-preset-test.yml@1.7.4
     with:
       matrix_config: >
         [
@@ -36,7 +36,7 @@ jobs:
         ]
 
   build-and-test:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-build-and-test.yml@1.7.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-build-and-test.yml@1.7.4
     with:
       matrix_config: >
         {
@@ -188,7 +188,7 @@ jobs:
         }
 
   vcpkg-ci:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-vcpkg-ci.yml@1.7.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-vcpkg-ci.yml@1.7.4
     with:
       port_name: beman-{{cookiecutter.project_name.replace('_', '-')}}
       feature_combinations: |
@@ -200,4 +200,4 @@ jobs:
   create-issue-when-fault:
     needs: [preset-test, build-and-test]
     if: failure() && github.event_name == 'schedule'
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.7.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.7.4

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit-check.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit-check.yml
@@ -17,4 +17,4 @@ permissions:
 
 jobs:
   pre-commit:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-pre-commit.yml@1.7.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-pre-commit.yml@1.7.4

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit-update.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/pre-commit-update.yml
@@ -10,7 +10,7 @@ on:
 {% raw -%}
 jobs:
   auto-update-pre-commit:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-update-pre-commit.yml@1.7.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-update-pre-commit.yml@1.7.4
     secrets:
       APP_ID: ${{ secrets.AUTO_PR_BOT_APP_ID }}
       PRIVATE_KEY: ${{ secrets.AUTO_PR_BOT_PRIVATE_KEY }}

--- a/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/vcpkg-release.yml
+++ b/cookiecutter/{{cookiecutter.project_name}}/.github/workflows/vcpkg-release.yml
@@ -6,7 +6,7 @@ on:
     types: [published]
 jobs:
   vcpkg-release:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-vcpkg-release.yml@1.7.3
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-vcpkg-release.yml@1.7.4
     with:
       port_name: beman-{{cookiecutter.project_name.replace('_', '-')}}
 {%- raw %}


### PR DESCRIPTION
This incorporates version pinning fixes that will ensure that future CMake updates don't break CI

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
